### PR TITLE
Added `StaticArrays` dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,4 +5,5 @@ version = "0.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Xtal = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"

--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -1,6 +1,7 @@
 module DFTraMO
 
 using LinearAlgebra
+using StaticArrays
 using Xtal
 
 include("Psphere.jl")


### PR DESCRIPTION
I use `SMatrix` and `SVector` extensively in `Xtal.jl` for the performance improvements - if the compiler can know that we're using vectors with only 3 elements, it can perform some optimizations on that. There's no changes to code with this, just the addition of the dependency.