### PR TITLE
Broadened type signatures and fixed docstrings

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -14,15 +14,15 @@ struct OrbitalParams
     coeff1::Float64
     coeff2::Float64
     function OrbitalParams(
-        atom_num::Int,
-        valence::Int,
-        l_quant::Int,
-        n_quant::Int,
-        IP::Float64,
-        exp1::Float64,
-        exp2::Float64,
-        coeff1::Float64,
-        coeff2::Float64
+        atom_num::Integer,
+        valence::Integer,
+        l_quant::Integer,
+        n_quant::Integer,
+        IP::Real,
+        exp1::Real,
+        exp2::Real,
+        coeff1::Real,
+        coeff2::Real
     )
     return new(atom_num,valence,l_quant,n_quant,IP,exp1,exp2,coeff1,coeff2)
     end
@@ -69,15 +69,16 @@ struct Supercell
     end
 end
 
-#==
+#=
 Might want this to make reconstruct_targets_DFT() neater?
 """
 """
 struct raMOSystemStatus
-    num_electrons_left::Int
-    num_occ_states::Int
-    num_planewaves::Int
-    kptlist::KPointlist{3}
-    G::Vector{Int}
+    num_electrons_left::Integer
+    num_occ_states::Integer
+    num_planewaves::Integer
+    kptlist::KPointList{3}
+    G::AbstractVector{<:Integer}
     #occ_coeff::
-end==#
+end
+=#

--- a/src/make_targets.jl
+++ b/src/make_targets.jl
@@ -1,14 +1,22 @@
 """
-    make_target_AO(make_target_AO(atom_site::Vector{Int}, orbital_to_use::Int, total_num_orbitals::Int) -> Vector
+    make_target_AO(
+        atom_site::AbstractVector{<:Integer},
+        target_orbital::Integer,
+        super::Supercell
+    ) -> Vector{Int}
 
-Returns a vector of length total_num_orbitals with "1" in the corresponding atomic orbital
+Returns a vector of length total_num_orbitals with "1" in the corresponding atomic orbital.
 """
 #==
 In the original DFTraMO, there is a make_target_massAO function, where instead of returning a
 vector with only one "1" in psi_target, it has multiple "1"s in psi_target. This is resolved by
 making atom_site a Vector, so we can get it for one site (length(atom_site) ==  1) or multiple.
 ==#
-function make_target_AO(atom_site::Vector{Int}, target_orbital::Int, super::Supercell)
+function make_target_AO(
+    atom_site::AbstractVector{<:Integer},
+    target_orbital::Integer,
+    super::Supercell
+)
     # psi_target has a length of total number of orbitals in the supercell
     psi_target = zeros(sum(super.orbitals))
     for atom in atom_site
@@ -18,12 +26,22 @@ function make_target_AO(atom_site::Vector{Int}, target_orbital::Int, super::Supe
 end
 
 """
-    make_target_cluster_sp(site_list::Vector{Vector{Real}}, radius::Real, site_num::Int, super::Supercell)
+    function make_target_cluster_sp(
+        site_list::AbstractVector{<:AbstractVector{<:Real}},
+        radius::Real,
+        site_num::Integer,
+        super::Supercell
+    ) -> Vector{Int}
 
 Returns a vector of length total_num_orbitals with "1" in the corresponding s & p atomic orbitals
 if they are within specified radius to the void.
 """
-function make_target_cluster_sp(site_list::Vector{Vector{Float64}}, radius::Real, site_num::Int, super::Supercell)
+function make_target_cluster_sp(
+    site_list::AbstractVector{<:AbstractVector{<:Real}},
+    radius::Real,
+    site_num::Integer,
+    super::Supercell
+)
     # psi_target has a length of total number of orbitals in the supercell
     psi_target = zeros(sum(super.orbitals))
     # Loops through every atom and checks to see if it's within the radius to the void site
@@ -55,15 +73,26 @@ function make_target_cluster_sp(site_list::Vector{Vector{Float64}}, radius::Real
 end
 
 """
-    make_target_hybrid()
+    make_target_hybrid(
+        cluster_list::AbstractVector{<:AbstractVector{<:Real}},
+        atom_num::Integer,
+        super::Supercell
+    )
 
-Makes a custom hybrid with manually specified coefficients from a cluster file that corresponds to an atom
+Makes a custom hybrid with manually specified coefficients from a cluster file that corresponds to
+an atom.
 """
 #==
 Currently echoes MATLAB version of DFT-raMO. Cluster file should have one Float per line,
 in multiples of 9.
+
+What's the return type? -BF
 ==#
-function make_target_hybrid(cluster_list::Vector{Vector{Float64}}, atom_num::Int, super::Supercell)
+function make_target_hybrid(
+    cluster_list::AbstractVector{<:AbstractVector{<:Real}},
+    atom_num::Integer,
+    super::Supercell
+)
     num_targets = length(cluster_list)/9
     psi_target = zeros(sum(super.orbitals), num_targets)
     AO_number = sum(super.orbitals[1:atom_num])-super.orbitals[atom_num]

--- a/src/raMO.jl
+++ b/src/raMO.jl
@@ -1,20 +1,20 @@
 """
-get_eht_params(atom_num::Int, atom_orbital::Int, eht_params::ehtParams) -> OrbitalParams
+get_eht_params(atom_num::Integer, atom_orbital::Integer, eht_params::ehtParams) -> OrbitalParams
 
-Search for parameters in the loaded ehtParams for corresponding atom. atom_orbital corresponds to the quantum number l.
+Search for parameters in the loaded ehtParams for corresponding atom. atom_orbital corresponds to
+the quantum number l.
 """
-function get_eht_params(atom_num::Int, atom_orbital::Int, eht_params::ehtParams)
+function get_eht_params(atom_num::Integer, atom_orbital::Integer, eht_params::ehtParams)
     return eht_params.data[atom_num, atom_orbital+1]
 end
 
-
 """
-    make_overlap_mat(occ_coeff, kpoint_repeating::Vector{Bool})
+    make_overlap_mat(occ_coeff, kpoint_repeating::AbstractVector{Bool})
 
-    Creates overlap matrix with occupied coefficients
-    If the kpoints are the same, they can overlap. Otherwise, they do not.
+Creates overlap matrix with occupied coefficients. If the kpoints are the same, they can overlap.
+Otherwise, they do not.
 """
-function make_overlap_mat(occ_coeff, kpoint_repeating::Vector{Bool})
+function make_overlap_mat(occ_coeff, kpoint_repeating::AbstractVector{Bool})
     num_occ_states = length(kpoint_repeating)
     S = zeros(num_occ_states,num_occ_states)
     kpoint_zero = findall(x -> x == 0, kpoint_repeating)
@@ -54,21 +54,30 @@ function generate_H(super::Supercell, ehtparams::ehtParams)
 end
 
 """
-    reconstruct_targets_DFT()
+    reconstruct_targets_DFT(
+        psi_target::AbstractArray{<:Real},
+        num_electrons_left::Integer,
+        run_name::AbstractString,
+        super::Supercell,
+        ehtparams::ehtParams,
+        wavefxn::ReciprocalWavefunction{3,Float32},
+        use_prev::Bool,
+        prev_mat::AbstractString=""
+    )
 
 The guts of DFTraMO.
 """
 # For now, will not use the raMOSystemStatus struct. This will be a to-do to clean up the code!
 function reconstruct_targets_DFT(
-    psi_target::Array{<:Real},
-    num_electrons_left::Int,
+    psi_target::AbstractArray{<:Real},
+    num_electrons_left::Integer,
     run_name::AbstractString,
     super::Supercell,
     ehtparams::ehtParams,
     wavefxn::ReciprocalWavefunction{3,Float32},
     use_prev::Bool,
     prev_mat::AbstractString=""
-    )
+)
 
     # Single target run or multiple targets
     num_targets = 1
@@ -120,19 +129,20 @@ function reconstruct_targets_DFT(
     end
 end
 
+# Add a docstring here...
 function calculate_overlap(
-    num_spin_states::Int,
-    num_spin_up::Int,
-    num_spin_down::Int,
-    num_target_orbitals::Int,
-    num_occ_states::Int,
-    kpoint_repeating::Vector{Bool},
-    atom_pos_fract::Vector{Float64},
+    num_spin_states::Integer,
+    num_spin_up::Integer,
+    num_spin_down::Integer,
+    num_target_orbitals::Integer,
+    num_occ_states::Integer,
+    kpoint_repeating::AbstractVector{Bool},
+    atom_pos_fract::AbstractVector{<:Real},
     reciprocal_lattice::ReciprocalBasis{3},
-    G::Vector{Int},
-    kptlist::Vector{Vector{Float64}},
-    e::Vector{OrbitalParams},
-    )
+    G::AbstractVector{<:Integer},
+    kptlist::AbstractVector{<:AbstractVector{<:Real}},
+    e::AbstractVector{OrbitalParams},
+)
     # Initialize output matrix
     overlap_target_occupied = zeros(num_spin_states, max(num_spin_up, num_spin_down), num_target_orbitals)
     # Initialize secondary overlap container
@@ -208,10 +218,10 @@ function calculate_overlap(
     end
 end
 """
-    N_L(l::Int)]
+    N_L(l::Integer)
 
-Returns a constant of the planewave expansion, equal to (im^l)*(4*pi*(2l+1))^0.5.
+Returns a constant of the planewave expansion, equal to `(im^l)*(4*pi*(2l+1))^0.5`.
 """
-function N_L(l::Int)
+function N_L(l::Integer)
     return (im^l)*(4*pi*(2l+1))^0.5
 end

--- a/src/radial_overlap.jl
+++ b/src/radial_overlap.jl
@@ -8,11 +8,11 @@ in case you may be wondering why there are discrepancies between the output here
 using SymPy
 using SpecialFunctions
 """
-    radial_overlap(n_quant::Int, l_quant::Int) -> a::Sym
+    radial_overlap(n_quant::Integer, l_quant::Integer) -> a::Sym
 
 Returns a SymPy object and prints the radial overlap solution at corresponding quantum numbers n, l.
 """
-function radial_overlap(n_quant::Int, l_quant::Int)
+function radial_overlap(n_quant::Integer, l_quant::Integer)
     # Radial component of STOs 
     @vars n ζ r
     rad_STO = (2*ζ)^n*sqrt((2*ζ)/factorial(2*n))*r^(n-1)*exp(-ζ*r)


### PR DESCRIPTION
I've made sure that functions that take only concrete types as arguments (`Int`, `Float64`, `Vector{Bool}`, etc.) have broad enough type signatures that they can handle other kinds of data. (For instance, by broadening `::Vector{Bool}` to `::AbstractVector{<:Bool}`, we can accept `BitVector` inputs)