### PR TITLE
Refactor printing and file opening methods

### DIFF
--- a/src/Psphere.jl
+++ b/src/Psphere.jl
@@ -9,7 +9,7 @@ function DFTraMO_overlap(
     radius::Real
 )
     # Opens xsf file
-    f = open(filename,"r")
+    f = open(filename)
     itr = eachline(f)
     
     # Grab cell vectors

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -104,7 +104,7 @@ Reads a GCOEFF.txt file within the specified energy range. Returns the unique G 
 coefficients, and k-point list corresponding to occupied states.
 """
 function read_GCOEFF(emin::Real, emax::Real)
-    open("GCOEFF.txt","r") do io
+    open("GCOEFF.txt") do io
         num_spin_states = parse(Int,readline(io))
         num_kpt = parse(Int,readline(io))
         num_band = parse(Int,readline(io))
@@ -238,7 +238,7 @@ states.
 """
 function read_site_list(filename::AbstractString)
     sitelist = Vector{Vector{Float64}}(undef,0)
-    open(filename,"r") do io
+    open(filename) do io
         ln = readlines(io)
         ln = filter(!isempty,split.(ln))
         # Removes first column of atomic labels, if any

--- a/src/raMO.jl
+++ b/src/raMO.jl
@@ -92,7 +92,7 @@ function reconstruct_targets_DFT(
     #output_name = @sprintf("%s_%05i.mat",run_name,num_electrons_left)
     if use_prev
         # TO DO: write code to load in previous matrix
-        open(prev_mat,"r")
+        open(prev_mat)
         println("Found and loaded remainder file ", prev_mat, ".")
     end
     


### PR DESCRIPTION
There were some calls to `string()` that were not necessary (I think you know this now, but `print()` and `println()` will do the same thing if you give it multiple arguments). 

I also changed the convention for calls to `open()` so that they use keyword arguments instead of string-based mode specifiers. So something like
```julia
open(filename, "w")
```
is now
```julia
open(filename, write=true)
```
This should be clearer to others reading the code. Also, `open()` assumes that the file is only open for reading if no keywords are specified, so you don't need to add `"r"` or `read=true`.