### PR TITLE
Updating dependencies to use Electrum.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,8 @@ version = "0.1.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Electrum = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Xtal = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"


### PR DESCRIPTION
The package won't load on a fresh pull since it references the old Xtal.jl name. I've updated `Project.toml` to reference the new name (Electrum.jl)