### PR TITLE
Refactoring `import_VASP()` (breaking change)

### DIFF
--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -70,6 +70,7 @@ Searches in the specified directory (defaults to the current directory if none i
 for a DFT-raMO run.
 """
 function import_VASP(directory::AbstractString="")
+    isdir(directory) || error("$directory is not a directory.")
     fermi = get_fermi(directory)
     geo = readPOSCAR(directory)
     wave = readWAVECAR(directory)


### PR DESCRIPTION
I've found some ways to simplify `import_VASP()` that takes advantage of new semantics with the VASP file reading capabilities of Electrum.jl.

Before merging, I'll note that the return type of the function has changed. Instead of returning a `Crystal{3}` and a `PeriodicAtomList{3}` that corresponds to the supercell defined by the VASP `KPOINTS` file, it returns a `Crystal{3}` that lazily references the supercell - this can be converted to a `PeriodicAtomList` by calling the `PeriodicAtomList` constructor.