### PR TITLE
Energy range

### DIFF
--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -43,7 +43,7 @@ function read_run_yaml(file::AbstractString, software::AbstractString="vasp")
         emax = parse_energy(software, emax)
     end
     emax < emin && error("emax cannot be less than emin.")
-    println("Energy range: ", @sprintf("%.3f", emin), " to ", @sprintf("%.3f", emax), " Ha.")
+    println("Energy range: ", @sprintf("%.3f", emin), " to ", @sprintf("%.3f", emax), " Ha (", @sprintf("%.3f", emin*Electrum.HARTREE2EV), " to ", @sprintf("%.3f", emax*Electrum.HARTREE2EV), " eV)")
     
     runs = get(data, "runs", nothing)
     println("Number of runs: ", length(runs))
@@ -129,34 +129,38 @@ function read_run_yaml(file::AbstractString, software::AbstractString="vasp")
 end
 
 """
-    parse_energy()
+    parse_energy(software::AbstractString, energy::AbstractString) -> n::Float64
 
 Parse energy values of the input yaml files and returns energies in Ha.
 """
-function parse_energy(software, energy)
+function parse_energy(software::AbstractString, energy::AbstractString)
     # Get energy range. Need to convert to Hartree
-    if typeof(energy) == String
-        ln = split(energy)
-        length(ln) > 2 && error("Check energy range.")
-        n = parse(Float64, ln[1])
-        if lowercase(ln[2]) == "ev"
-            n = n*Electrum.EV2HARTREE
-        elseif !(lowercase(ln[2]) == "ha")
-            error(ln[2], " is not a valid energy unit. Use Ha or eV.")
-        end
-    elseif typeof(energy) <: Real
-        if software == "vasp"
-            e = Electrum.EV2HARTREE
-            units = "eV"
-        else
-            e = 1
-            units = "Ha"
-        end
-        warn("No energy units are specified. Defaulting to ", units, " (", software, ")")
-        n = energy*e
-    else
-        error("Unable to parse energy. Check energy range.")
+    ln = split(energy)
+    length(ln) > 2 && error("Check energy range.")
+    n = parse(Float64, ln[1])
+    if lowercase(ln[2]) == "ev"
+        n = n*Electrum.EV2HARTREE
+    elseif !(lowercase(ln[2]) == "ha")
+        error(ln[2], " is not a valid energy unit. Use Ha or eV.")
     end
+    return n
+end
+
+"""
+    parse_energy(software::AbstractString, energy::Real) -> n::Float64
+
+Parse energy values of the input yaml files and returns energies in Ha.
+"""
+function parse_energy(software::AbstractString, energy::Real)
+    if software == "vasp"
+        e = Electrum.EV2HARTREE
+        units = "eV"
+    else
+        e = 1
+        units = "Ha"
+    end
+    warn("No energy units are specified. Defaulting to ", units, " (", software, ")")
+    n = energy*e
     return n
 end
 

--- a/src/runs.jl
+++ b/src/runs.jl
@@ -211,8 +211,8 @@ end
 Reads a run.yaml file and executes DFTraMO.
 """
 function dftramo_run(filename::AbstractString, software::AbstractString="vasp")
-    (runs, checkpoint, auto_psphere, dftinfo) = read_run_yaml(filename, software)
-    occ_states = get_occupied_states(dftinfo.wave, dftinfo.fermi.fermi*Electrum.EV2HARTREE)
+    (runs, checkpoint, auto_psphere, dftinfo, emin, emax) = read_run_yaml(filename, software)
+    occ_states = get_occupied_states(dftinfo.wave, emin, emax)
     super = Supercell(dftinfo.xtal, orb_dict)
     S = make_overlap_mat(occ_states)
     H = DFTraMO.generate_H(super, DFTRAMO_EHT_PARAMS)

--- a/test/input/ScAl3.yaml
+++ b/test/input/ScAl3.yaml
@@ -1,5 +1,7 @@
 checkpoint:
 auto_psphere: true
+emin: -100
+emax:
 runs:
   - name: 1_Sc-Sc
     type: sp

--- a/test/input/ScAl3.yaml
+++ b/test/input/ScAl3.yaml
@@ -1,7 +1,7 @@
 checkpoint:
 auto_psphere: true
-emin: -100
-emax:
+emin: -100 eV
+emax: 0.25 Ha
 runs:
   - name: 1_Sc-Sc
     type: sp

--- a/test/inputs.jl
+++ b/test/inputs.jl
@@ -1,5 +1,8 @@
 @testset "Inputs" begin
     cd("input/") do
-        input = read_run_yaml("ScAl3.yaml")
+        (runs, checkpoint, auto_psphere, dftinfo, emin, emax) = read_run_yaml("ScAl3.yaml")
+        @test length(runs) == 5
+        @test emin == -100*DFTraMO.Electrum.EV2HARTREE
+        @test emax == 0.25
     end
 end


### PR DESCRIPTION
New optional keywords for the input yaml file: `emin` and `emax`. These specify the energy range of the planewaves which DFT-raMO uses for its analysis. Energies can be specified in eV or Ha, or DFT-raMO will guess the units based on the software used. If left blank, DFT-raMO will include all bands up to the Fermi energy, by default.