### PR TITLE
Included missing module prefixes

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -102,9 +102,9 @@ struct Supercell
     end
 end
 
-basis(s::Supercell) = basis(s.atomlist)
-PeriodicAtomList(s::Supercell) = s.atomlist
-getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
+Electrum.basis(s::Supercell) = basis(s.atomlist)
+Electrum.PeriodicAtomList(s::Supercell) = s.atomlist
+Base.getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
 
 """
     OccupiedStates(

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -1,6 +1,6 @@
 """
     function write_to_XSF(
-        isosurf::AbstractArray{ComplexF64, 3},
+        isosurf::AbstractArray{<:Number, 3},
         xtal::AbstractAtomList{3},
         filename::AbstractString
     )
@@ -8,7 +8,7 @@
 Writes an XSF using the real components of `isosurf`.
 """
 function write_to_XSF(
-    isosurf::AbstractArray{ComplexF64, 3},
+    isosurf::AbstractArray{<:Number, 3},
     xtal::AbstractAtomList{3},
     filename::AbstractString
 )


### PR DESCRIPTION
Unless we explicitly import `Electrum.basis`, the definition of `basis(::Supercell)` needs to include the module name prefix. That way there is no distinction between the Electrum.jl definition of `basis` and the DFT-raMO defintion of `basis`.

I noticed the `basis_bug` branch and the solution involved a high degree of [type piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy), which is something we should avoid in general. (For issues that arise with Electrum that would require fixes to that package specifically.)

If desired, we can change this so that we have a line `import Electrum: basis` with other functions we might want to skip the prefixing for.