### PR TITLE
Changed `InputOrigin` type to an enumeration by `Symbol`

### DIFF
--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -10,7 +10,7 @@ include("data.jl")
 export OrbitalParams, ehtParams, Supercell, OccupiedStates
 
 include("software.jl")
-export raMOinput, FromABINIT, FromVASP
+export raMOinput, InputOrigin, FromABINIT, FromVASP
 
 include("raMO.jl")
 export get_eht_params, make_overlap_mat,

--- a/src/software.jl
+++ b/src/software.jl
@@ -9,6 +9,7 @@ struct raMOInput
     fermi::Float64
 end
 
+Electrum.basis(x::raMOInput) = basis(x.xtal.atoms)
 Electrum.Crystal(x::raMOInput) = x.xtal
 Electrum.PeriodicAtomList(x::raMOInput) = x.xtal.atoms
 Electrum.PlanewaveWavefunction(x::raMOInput) = x.wave

--- a/src/software.jl
+++ b/src/software.jl
@@ -30,6 +30,22 @@ end
 const SUPPORTED_SOFTWARE = (:abinit, :vasp)
 
 """
+    DFTraMO.length_conversion(i::InputOrigin) -> Real
+
+Provides the conversion factor for the default length units for the software package indicated by
+`i` to Bohr. By default, this is equal to 1 (we assume most packages use Hartree atomic units).
+"""
+length_conversion(::InputOrigin) = 1
+
+"""
+    DFTraMO.energy_conversion(i::InputOrigin) -> Real
+
+Provides the conversion factor for the default energy units for the software package indicated by
+`i` to Hartree. By default, this is equal to 1 (we assume most packages use Hartree atomic units).
+"""
+energy_conversion(::InputOrigin) = 1
+
+"""
     DFTraMO.FromABINIT
 
 Dispatch type for reading abinit WFK outputs.
@@ -43,6 +59,9 @@ Dispatch type for reading VASP calculation outputs (specifically, the `POSCAR`, 
 `KPOINTS`, and `OUTCAR` files.)
 """
 const FromVASP = InputOrigin{:vasp}
+# Default units for VASP are angstroms and electron-volts
+energy_conversion(::FromVASP) = Electrum.EV2HARTREE
+length_conversion(::FromVASP) = Electrum.ANG2BOHR
 
 function raMOInput(io::IO, ::FromABINIT)
     h = Electrum.read_abinit_header(io)

--- a/src/software.jl
+++ b/src/software.jl
@@ -17,30 +17,32 @@ Electrum.fermi(x::raMOInput) = x.fermi
 kptmesh(x::raMOInput) = x.xtal.set_transform
 
 """
-    DFTraMO.InputOrigin
+    DFTraMO.InputOrigin{S}
 
-Dispatch type for various computational chemistry packages (for a complete list, run
-`subtypes(DFTraMO.InputOrigin)` in the REPL).
+Dispatch type to indicate the software package which generated the input files for DFT-raMO. The
+type parameter `S` is a `Symbol`, all lowercase, which contains the name of the software package.
+
+To see a list of the supported software packages, evaluate `DFTraMO.SUPPORTED_SOFTWARE`.
 """
-abstract type InputOrigin
+struct InputOrigin{S}
 end
+
+const SUPPORTED_SOFTWARE = (:abinit, :vasp)
 
 """
     DFTraMO.FromABINIT
 
 Dispatch type for reading abinit WFK outputs.
 """
-struct FromABINIT
-end
+const FromABINIT = InputOrigin{:abinit}
 
 """
     DFTraMO.FromVASP
-
+ 
 Dispatch type for reading VASP calculation outputs (specifically, the `POSCAR`, `WAVECAR`,
 `KPOINTS`, and `OUTCAR` files.)
 """
-struct FromVASP
-end
+const FromVASP = InputOrigin{:vasp}
 
 function raMOInput(io::IO, ::FromABINIT)
     h = Electrum.read_abinit_header(io)


### PR DESCRIPTION
Rather than having `InputOrigin` be an abstract type, I've decided to turn it into a parametric type `InputOrigin{S}` where `S` is a `Symbol` that corresponds to the software package. `FromABINIT` is now an alias for `InputOrigin{:abinit}` and `FromVASP` is an alias for `InputOrigin{:vasp}`.

On top of that, I've included the `length_conversion` and `energy_conversion` methods that provide the conversion factor between the package's units and the Hartree atomic units assumed by Electrum. By default, `InputOrigin` instances default to assuming the package which generated the input also uses Hartree atomic units. We'll want to override this for packages like VASP which use angstroms and eV (which I've already done).

This shouldn't affect any current functionality if none of the methods in the current DFT-raMO pipeline call `raMOInput` constructors.