### PR TITLE
Converted constants to all caps

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -1,3 +1,4 @@
+# TODO: is there a reason why neither orb nor val_e are constants/have no docstring?
 orb = [
     1, 1, 1, 1, 4, 4, 4, 4, 4, 4,
     1, 1, 4, 4, 4, 4, 4, 4,
@@ -21,11 +22,11 @@ val_e = [
     4, 5, 6, 7, 8, 9, 10, 11, 12, 3, 4, 5, 6, 7, 8,
 ]
 
-const orb_dict = Dict{String, Int}(
+const ORB_DICT = Dict{String, Int}(
     [Electrum.ELEMENTS[n] => orb[n] for n in eachindex(orb)]
 )
 
-const e_dict = Dict{String, Int}(
+const E_DICT = Dict{String, Int}(
     [Electrum.ELEMENTS[n] => val_e[n] for n in eachindex(val_e)]
 )
 

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -6,14 +6,14 @@ Automatically runs DFTraMO from a configuration yaml file.
 function dftramo_run(filename::AbstractString, software::AbstractString="vasp")
     (runs, checkpoint, auto_psphere, dftinfo, emin, emax) = read_run_yaml(filename, software)
     occ_states = get_occupied_states(dftinfo.wave, emin, emax)
-    super = Supercell(dftinfo.xtal, orb_dict)
+    super = Supercell(dftinfo.xtal, ORB_DICT)
     S = make_overlap_mat(occ_states)
     H = generate_H(super, DFTRAMO_EHT_PARAMS)
     
     if !isnothing(checkpoint)
         (psi_previous, num_electrons_left, num_raMO) = import_checkpoint(checkpoint)
     else
-        num_electrons_left = sum([get(e_dict, n.atom.name, 0) for n in dftinfo.xtal.atoms])
+        num_electrons_left = sum([get(E_DICT, n.atom.name, 0) for n in dftinfo.xtal.atoms])
         num_raMO = 0
         psi_previous = diagm(ones(size(occ_states.coeff)[2]))
         psi_previous = ComplexF32.(repeat(psi_previous, 1, 1, 2)) #spin states to be implemented


### PR DESCRIPTION
This should be the default for any new constant values introduced.

I also noticed some arrays that are being used to construct these constants that are not constants themselves - perhaps we should change them as well.
