### PR TITLE
Refactor/structs for ramo

### DIFF
--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -7,7 +7,7 @@ using ProgressBars, Crayons
 using Requires
 
 include("data.jl")
-export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMODFTData
+export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMODFTData, raMOInput
 
 include("software.jl")
 export InputOrigin, FromABINIT, FromVASP

--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -27,7 +27,7 @@ export import_VASP, import_abinit,get_occupied_states, read_eht_params, read_sit
 import_checkpoint, import_raMO
 
 include("yaml.jl")
-export dftramo_run, read_run_yaml, parse_energy, parse_sites
+export dftramo_run, parse_energy, parse_sites, read_yaml
 
 include("outputs.jl")
 export write_to_XSF, raMO_to_density

--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -7,7 +7,7 @@ using ProgressBars, Crayons
 using Requires
 
 include("data.jl")
-export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMOInput
+export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMODFTData
 
 include("software.jl")
 export InputOrigin, FromABINIT, FromVASP

--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -7,10 +7,10 @@ using ProgressBars, Crayons
 using Requires
 
 include("data.jl")
-export OrbitalParams, ehtParams, Supercell, OccupiedStates
+export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMOInput
 
 include("software.jl")
-export raMOinput, InputOrigin, FromABINIT, FromVASP
+export InputOrigin, FromABINIT, FromVASP
 
 include("raMO.jl")
 export get_eht_params, make_overlap_mat,

--- a/src/data.jl
+++ b/src/data.jl
@@ -125,8 +125,8 @@ Base.getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
 Contains all of the crystal and wavefunction information needed to perform a DFT-raMO run.
 """
 struct raMOInput
-    xtal::Crystal
-    wave::PlanewaveWavefunction
+    xtal::Crystal{3}
+    wave::PlanewaveWavefunction{3,Float32}
     fermi::Float64
 end
 
@@ -294,7 +294,7 @@ Base.getindex(x::raMORuns, i) = x.runlist[i]
     xtal::PeriodicAtomList{3}
     geo::PeriodicAtomList{3}
     kpt::AbstractVector{Int}
-    wave::Planewavefunction
+    wave::PlanewaveWavefunction{3,Float32}
     num_raMO::Int
     num_electrons_left::Int
 end==#

--- a/src/data.jl
+++ b/src/data.jl
@@ -135,7 +135,8 @@ Electrum.Crystal(x::raMODFTData) = x.xtal
 Electrum.PeriodicAtomList(x::raMODFTData) = x.xtal.atoms
 Electrum.PlanewaveWavefunction(x::raMODFTData) = x.wave
 Electrum.fermi(x::raMODFTData) = x.fermi
-kptmesh(x::raMODFTData) = x.xtal.transform
+kptmesh(x::raMODFTData) = diag(x.xtal.transform)
+Electrum.supercell(x::raMODFTData) = supercell(x.xtal.atoms, kptmesh(x))
 
 """
     OccupiedStates(
@@ -286,8 +287,11 @@ raMODFTData(x::raMOInput) = x.dftdata
 Electrum.Crystal(x::raMOInput) = x.dftdata.xtal
 Electrum.basis(x::raMOInput) = basis(x.dftdata.xtal)
 Electrum.PlanewaveWavefunction(x::raMOInput) = x.dftdata.wave
+Electrum.PeriodicAtomList(x::raMOInput) = x.dftdata.xtal.atoms
+Electrum.supercell(x::raMOInput) = supercell(x.dftdata)
 # Index by run
 Base.getindex(x::raMOInput, i) = x.runlist[i]
+Base.iterate(x::raMOInput, i=1) = i > length(x.runlist) ? nothing : (x.runlist[i], i+1)
 
 #==struct raMOStatus
     fermi::NamedTuple{(:fermi, :alphabeta), Tuple{Float64, Float64}}

--- a/src/data.jl
+++ b/src/data.jl
@@ -203,7 +203,7 @@ struct raMOCheckpoint{T<:Number} <: AbstractArray{T,3}
         electrons_left::Integer,
         num_ramos::Integer
     ) where T
-        @assert electrons_left >= 0 "The number of electrons left is a negative value."
+        #@assert electrons_left >= 0 "The number of electrons left is a negative value."
         @assert num_ramos >= 0 "The number of raMOs reconstructed is a negative value."
         return new(coeff, electrons_left, num_ramos)
     end

--- a/src/data.jl
+++ b/src/data.jl
@@ -189,6 +189,38 @@ struct RunInfo
 end
 
 """
+    raMOCheckpoint{T}
+
+Contains checkpoint data, a 3D array of remainder coefficients, as well as the number of electrons
+left and the number of the current raMO in the sequence.
+"""
+struct raMOCheckpoint{T<:Number} <: AbstractArray{T,3}
+    coeff::Array{T,3}
+    electrons_left::Int
+    num_ramos::Int
+    function raMOCheckpoint{T}(
+        coeff::AbstractArray{3},
+        electrons_left::Integer,
+        num_ramos::Integer
+    ) where T
+        @assert electrons_left >= 0 "The number of electrons left is a negative value."
+        @assert num_ramos >= 0 "The number of raMOs reconstructed is a negative value."
+        return new(coeff, electrons_left, num_ramos)
+    end
+end
+
+function raMOCheckpoint(
+    psi::AbstractArray{T,3},
+    electrons_left::Integer,
+    num_ramos::Integer
+) where T
+    return raMOCheckpoint{T}(psi, electrons_left, num_ramos)
+end
+
+Base.size(x::raMOCheckpoint) = size(x.coeff)
+Base.getindex(x::raMOCheckpoint, i...) = x.coeff[i]
+
+"""
     raMORuns
 
 Contains all of the information supplied by the user in the YAML file with raMO input data. This

--- a/src/data.jl
+++ b/src/data.jl
@@ -120,22 +120,22 @@ Electrum.PeriodicAtomList(s::Supercell) = s.atomlist
 Base.getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
 
 """
-    raMOInput
+    raMODFTData
 
 Contains all of the crystal and wavefunction information needed to perform a DFT-raMO run.
 """
-struct raMOInput
+struct raMODFTData
     xtal::Crystal{3}
     wave::PlanewaveWavefunction{3,Float32}
     fermi::Float64
 end
 
-Electrum.basis(x::raMOInput) = basis(x.xtal.atoms)
-Electrum.Crystal(x::raMOInput) = x.xtal
-Electrum.PeriodicAtomList(x::raMOInput) = x.xtal.atoms
-Electrum.PlanewaveWavefunction(x::raMOInput) = x.wave
-Electrum.fermi(x::raMOInput) = x.fermi
-kptmesh(x::raMOInput) = x.xtal.transform
+Electrum.basis(x::raMODFTData) = basis(x.xtal.atoms)
+Electrum.Crystal(x::raMODFTData) = x.xtal
+Electrum.PeriodicAtomList(x::raMODFTData) = x.xtal.atoms
+Electrum.PlanewaveWavefunction(x::raMODFTData) = x.wave
+Electrum.fermi(x::raMODFTData) = x.fermi
+kptmesh(x::raMODFTData) = x.xtal.transform
 
 """
     OccupiedStates(
@@ -228,14 +228,14 @@ includes the DFT data (crystal, wavefunction, Fermi energy), run list, energy ra
 reconstruction, path to the checkpoint file, and whether to automatically use `Psphere`.
 """
 struct raMORuns
-    dftdata::raMOInput
+    dftdata::raMODFTData
     runlist::Vector{RunInfo}
     emin::Float64
     emax::Float64
     checkpoint::String  # TODO: should we use some sort of IO type? or checkpoint container?
     auto_psphere::Bool
     function raMORuns(
-        dftdata::raMOInput,
+        dftdata::raMODFTData,
         runlist,
         emin::Real,
         emax::Real,
@@ -250,7 +250,7 @@ end
 
 """
     raMORuns(
-        dftdata::raMOInput,
+        dftdata::raMODFTData,
         runlist;
         auto_psphere = false,
         checkpoint = "",
@@ -266,12 +266,12 @@ If `checkpoint` is unset, the checkpoint path is the empty string, corresponding
 file being used.
 
 If `emin` is unset, then the value is automatically set to the lowest energy in the range of the
-`PlanewaveWavefunction` within the `raMOInput`.
+`PlanewaveWavefunction` within the `raMODFTData`.
 
 If `emax` is unset, then the value is automatically set to the Fermi energy of the wavefunction.
 """
 function raMORuns(
-    dftdata::raMOInput,
+    dftdata::raMODFTData,
     runlist;
     auto_psphere = false,
     checkpoint::AbstractString = "",
@@ -281,7 +281,7 @@ function raMORuns(
     return raMORuns(dftdata, runlist, emin, emax, checkpoint, auto_psphere)
 end
 
-raMOInput(x::raMORuns) = x.dftdata
+raMODFTData(x::raMORuns) = x.dftdata
 
 Electrum.Crystal(x::raMORuns) = x.dftdata.xtal
 Electrum.basis(x::raMORuns) = basis(x.dftdata.xtal)

--- a/src/data.jl
+++ b/src/data.jl
@@ -221,20 +221,20 @@ Base.size(x::raMOCheckpoint) = size(x.coeff)
 Base.getindex(x::raMOCheckpoint, i...) = x.coeff[i]
 
 """
-    raMORuns
+    raMOInput
 
 Contains all of the information supplied by the user in the YAML file with raMO input data. This
 includes the DFT data (crystal, wavefunction, Fermi energy), run list, energy ranges for orbital
 reconstruction, path to the checkpoint file, and whether to automatically use `Psphere`.
 """
-struct raMORuns
+struct raMOInput
     dftdata::raMODFTData
     runlist::Vector{RunInfo}
     emin::Float64
     emax::Float64
     checkpoint::String  # TODO: should we use some sort of IO type? or checkpoint container?
     auto_psphere::Bool
-    function raMORuns(
+    function raMOInput(
         dftdata::raMODFTData,
         runlist,
         emin::Real,
@@ -249,7 +249,7 @@ struct raMORuns
 end
 
 """
-    raMORuns(
+    raMOInput(
         dftdata::raMODFTData,
         runlist;
         auto_psphere = false,
@@ -258,7 +258,7 @@ end
         emax = fermi(dftdata)
     )
 
-Constructs a `raMORuns` object with some assumptions implemented as keyword arguments.
+Constructs a `raMOInput` object with some assumptions implemented as keyword arguments.
 
 `auto_psphere` is set to false if not specified.
 
@@ -270,7 +270,7 @@ If `emin` is unset, then the value is automatically set to the lowest energy in 
 
 If `emax` is unset, then the value is automatically set to the Fermi energy of the wavefunction.
 """
-function raMORuns(
+function raMOInput(
     dftdata::raMODFTData,
     runlist;
     auto_psphere = false,
@@ -278,16 +278,16 @@ function raMORuns(
     emin::Real = minimum(dftdata.wave.energies),
     emax::Real = fermi(dftdata)
 )
-    return raMORuns(dftdata, runlist, emin, emax, checkpoint, auto_psphere)
+    return raMOInput(dftdata, runlist, emin, emax, checkpoint, auto_psphere)
 end
 
-raMODFTData(x::raMORuns) = x.dftdata
+raMODFTData(x::raMOInput) = x.dftdata
 
-Electrum.Crystal(x::raMORuns) = x.dftdata.xtal
-Electrum.basis(x::raMORuns) = basis(x.dftdata.xtal)
-Electrum.PlanewaveWavefunction(x::raMORuns) = x.dftdata.wave
+Electrum.Crystal(x::raMOInput) = x.dftdata.xtal
+Electrum.basis(x::raMOInput) = basis(x.dftdata.xtal)
+Electrum.PlanewaveWavefunction(x::raMOInput) = x.dftdata.wave
 # Index by run
-Base.getindex(x::raMORuns, i) = x.runlist[i]
+Base.getindex(x::raMOInput, i) = x.runlist[i]
 
 #==struct raMOStatus
     fermi::NamedTuple{(:fermi, :alphabeta), Tuple{Float64, Float64}}

--- a/src/data.jl
+++ b/src/data.jl
@@ -244,7 +244,7 @@ struct raMOInput
     )
         @assert emin < emax "Minimum energy is not less than maximum energy"
         isnothing(auto_psphere) && (auto_psphere = false)
-        return new(dftdata, collect(runlist), checkpoint, emin, emax, auto_psphere)
+        return new(dftdata, collect(runlist), emin, emax, checkpoint, auto_psphere)
     end
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -30,7 +30,19 @@ const E_DICT = Dict{String, Int}(
     [Electrum.ELEMENTS[n] => val_e[n] for n in eachindex(val_e)]
 )
 
-const AO_RUNS = Dict("s"=>1, "px"=>2, "py"=>3, "pz"=>4, "dx2y2"=>5, "dx2-y2"=>5, "dz2"=>6, "dxy"=>7, "dxz"=>8, "dyz"=>9)
+# TODO: can we use regex to handle this more efficiently?
+const AO_RUNS = Dict(
+    "s"     => 1,
+    "px"    => 2,
+    "py"    => 3,
+    "pz"    => 4,
+    "dx2y2" => 5,
+    "dx2-y2"=> 5,
+    "dz2"   => 6,
+    "dxy"   => 7,
+    "dxz"   => 8,
+    "dyz"   => 9
+)
 
 const CAGE_RUNS = [
     "sp" # hybrid cage states by distance

--- a/src/data.jl
+++ b/src/data.jl
@@ -289,9 +289,10 @@ Electrum.basis(x::raMOInput) = basis(x.dftdata.xtal)
 Electrum.PlanewaveWavefunction(x::raMOInput) = x.dftdata.wave
 Electrum.PeriodicAtomList(x::raMOInput) = x.dftdata.xtal.atoms
 Electrum.supercell(x::raMOInput) = supercell(x.dftdata)
-# Index by run
+
+# Size and indexing depend on the run list.
+Base.size(x::raMOInput) = size(x.runlist)
 Base.getindex(x::raMOInput, i) = x.runlist[i]
-Base.iterate(x::raMOInput, i=1) = i > length(x.runlist) ? nothing : (x.runlist[i], i+1)
 
 #==struct raMOStatus
     fermi::NamedTuple{(:fermi, :alphabeta), Tuple{Float64, Float64}}

--- a/src/data.jl
+++ b/src/data.jl
@@ -181,7 +181,7 @@ struct RunInfo
         radius::Number,
         rsphere::Number
     )
-        @assert all(sign.(sites) > 0) "Some site values are not positive integers."
+        @assert all(sign.(sites) .> 0) "Some site values are not positive integers."
         @assert sign(radius) >= 0 "Radius is a negative value."
         @assert sign(rsphere) >= 0 "Rsphere is a negative value."
         return new(name, type, site_file, sites, radius, rsphere)

--- a/src/data.jl
+++ b/src/data.jl
@@ -120,6 +120,24 @@ Electrum.PeriodicAtomList(s::Supercell) = s.atomlist
 Base.getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
 
 """
+    raMOInput
+
+Contains all of the crystal and wavefunction information needed to perform a DFT-raMO run.
+"""
+struct raMOInput
+    xtal::Crystal
+    wave::PlanewaveWavefunction
+    fermi::Float64
+end
+
+Electrum.basis(x::raMOInput) = basis(x.xtal.atoms)
+Electrum.Crystal(x::raMOInput) = x.xtal
+Electrum.PeriodicAtomList(x::raMOInput) = x.xtal.atoms
+Electrum.PlanewaveWavefunction(x::raMOInput) = x.wave
+Electrum.fermi(x::raMOInput) = x.fermi
+kptmesh(x::raMOInput) = x.xtal.transform
+
+"""
     OccupiedStates(
         coeff::AbstractMatrix{<:Number},
         kpt::AbstractMatrix{<:AbstractVector},

--- a/src/data.jl
+++ b/src/data.jl
@@ -126,7 +126,7 @@ Contains all of the crystal and wavefunction information needed to perform a DFT
 """
 struct raMODFTData
     xtal::Crystal{3}
-    wave::PlanewaveWavefunction{3,Float32}
+    wave::PlanewaveWavefunction{3,ComplexF32}
     fermi::Float64
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -143,24 +143,18 @@ struct OccupiedStates
 end
 
 """
-    RunInfo(
-        name::AbstractString,
-        type::AbstractString,
-        site_file::AbstractString,
-        sites::AbstractVector{<:Integer},
-        radius::Number,
-        rsphere::Number
-    )
+    DFTraMO.RunInfo
+
+Contains information from a run entry in the YAML input file. All runs in the file are collected
+a single `Vector{RunInfo}` object when `dftramo_run()` is called.
 """
-# TODO: add documentation describing what this does
-# Also, does this need to be mutable?
-mutable struct RunInfo
+struct RunInfo
     name::String
-    const type::String
-    const site_file::String
+    type::String
+    site_file::String
     sites::Vector{Int}
-    const radius::Float64
-    const rsphere::Float64
+    radius::Float64
+    rsphere::Float64
     function RunInfo(
         name::AbstractString,
         type::AbstractString,

--- a/src/data.jl
+++ b/src/data.jl
@@ -163,6 +163,9 @@ struct RunInfo
         radius::Number,
         rsphere::Number
     )
+        @assert all(sign.(sites) > 0) "Some site values are not positive integers."
+        @assert sign(radius) >= 0 "Radius is a negative value."
+        @assert sign(rsphere) >= 0 "Rsphere is a negative value."
         return new(name, type, site_file, sites, radius, rsphere)
     end
 end

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -99,6 +99,9 @@ function get_occupied_states(wave::PlanewaveWavefunction, emin::Real, emax::Real
     return OccupiedStates(coeff, kpt, hkl_list)
 end
 
+get_occupied_states(x::raMOInput, emin::Real, emax::Real) = get_occupied_states(x.wave, emin, emax)
+get_occupied_states(r::raMORuns) = get_occupied_states(PlanewaveWavefunction(r), r.emin, r.emax)
+
 """
     read_eht_params(paramsfile::AbstractString) -> mat::ehtParams 
 

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -100,7 +100,7 @@ function get_occupied_states(wave::PlanewaveWavefunction, emin::Real, emax::Real
 end
 
 get_occupied_states(x::raMODFTData, emin::Real, emax::Real) = get_occupied_states(x.wave, emin, emax)
-get_occupied_states(r::raMORuns) = get_occupied_states(PlanewaveWavefunction(r), r.emin, r.emax)
+get_occupied_states(r::raMOInput) = get_occupied_states(PlanewaveWavefunction(r), r.emin, r.emax)
 
 """
     read_eht_params(paramsfile::AbstractString) -> mat::ehtParams 

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -99,7 +99,7 @@ function get_occupied_states(wave::PlanewaveWavefunction, emin::Real, emax::Real
     return OccupiedStates(coeff, kpt, hkl_list)
 end
 
-get_occupied_states(x::raMOInput, emin::Real, emax::Real) = get_occupied_states(x.wave, emin, emax)
+get_occupied_states(x::raMODFTData, emin::Real, emax::Real) = get_occupied_states(x.wave, emin, emax)
 get_occupied_states(r::raMORuns) = get_occupied_states(PlanewaveWavefunction(r), r.emin, r.emax)
 
 """

--- a/src/software.jl
+++ b/src/software.jl
@@ -70,7 +70,7 @@ File names may be specified through the argument order given above, or with keyw
 have no fixed order.
 """
 function raMODFTData(POSCAR, WAVECAR, KPOINTS, OUTCAR, ::FromVASP)
-    fermi = get_fermi(OUTCAR) * Electrum.EV2HARTREE
+    fermi = get_fermi(OUTCAR).fermi
     geo = readPOSCAR(POSCAR)
     wave = readWAVECAR(WAVECAR, quiet = true)
     kpt = parse.(Int, split(readlines(KPOINTS)[4]))

--- a/src/software.jl
+++ b/src/software.jl
@@ -1,22 +1,4 @@
 """
-    raMOInput
-
-Contains all of the crystal and wavefunction information needed to perform a DFT-raMO run.
-"""
-struct raMOInput
-    xtal::Crystal
-    wave::PlanewaveWavefunction
-    fermi::Float64
-end
-
-Electrum.basis(x::raMOInput) = basis(x.xtal.atoms)
-Electrum.Crystal(x::raMOInput) = x.xtal
-Electrum.PeriodicAtomList(x::raMOInput) = x.xtal.atoms
-Electrum.PlanewaveWavefunction(x::raMOInput) = x.wave
-Electrum.fermi(x::raMOInput) = x.fermi
-kptmesh(x::raMOInput) = x.xtal.set_transform
-
-"""
     DFTraMO.InputOrigin{S}
 
 Dispatch type to indicate the software package which generated the input files for DFT-raMO. The

--- a/src/software.jl
+++ b/src/software.jl
@@ -45,17 +45,17 @@ const FromVASP = InputOrigin{:vasp}
 energy_conversion(::FromVASP) = Electrum.EV2HARTREE
 length_conversion(::FromVASP) = Electrum.ANG2BOHR
 
-function raMOInput(io::IO, ::FromABINIT)
+function raMODFTData(io::IO, ::FromABINIT)
     h = Electrum.read_abinit_header(io)
     seekstart(io)
-    return raMOinput(Crystal(h), read_abinit_WFK(io)["wavefunction"], h[:fermi])
+    return raMODFTData(Crystal(h), read_abinit_WFK(io)["wavefunction"], h[:fermi])
 end
 
-raMOInput(file, ::FromABINIT) = open(io -> raMOInput(io, FromABINIT()), file)
+raMODFTData(file, ::FromABINIT) = open(io -> raMODFTData(io, FromABINIT()), file)
 
 """
-    raMOInput(POSCAR, WAVECAR, KPOINTS, OUTCAR, ::FromVASP)
-    raMOInput(;
+    raMODFTData(POSCAR, WAVECAR, KPOINTS, OUTCAR, ::FromVASP)
+    raMODFTData(;
         POSCAR = "POSCAR",
         WAVECAR = "WAVECAR",
         KPOINTS = "KPOINTS",
@@ -69,36 +69,36 @@ or path types if another package provides them (for more details, see the Electr
 File names may be specified through the argument order given above, or with keyword arguments which
 have no fixed order.
 """
-function raMOInput(POSCAR, WAVECAR, KPOINTS, OUTCAR, ::FromVASP)
+function raMODFTData(POSCAR, WAVECAR, KPOINTS, OUTCAR, ::FromVASP)
     fermi = get_fermi(OUTCAR) * Electrum.EV2HARTREE
     geo = readPOSCAR(POSCAR)
     wave = readWAVECAR(WAVECAR, quiet = true)
     kpt = parse.(Int, split(readlines(KPOINTS)[4]))
     # Use a Crystal to lazily reference the supercell
     xtal = set_transform!(Crystal(geo), kpt)
-    return raMOInput(xtal, wave, fermi) 
+    return raMODFTData(xtal, wave, fermi) 
 end
 
-function raMOInput(;
+function raMODFTData(;
     POSCAR = "POSCAR",
     WAVECAR = "WAVECAR",
     KPOINTS = "KPOINTS",
     OUTCAR = "OUTCAR"
 )
-    return raMOInput(POSCAR, WAVECAR, KPOINTS, OUTCAR, FromVASP())
+    return raMODFTData(POSCAR, WAVECAR, KPOINTS, OUTCAR, FromVASP())
 end
 
 """
-    raMOInput(directory, FromVASP(); CONTCAR=false)
-    raMOInput(FromVASP(); CONTCAR=false)
+    raMODFTData(directory, FromVASP(); CONTCAR=false)
+    raMODFTData(FromVASP(); CONTCAR=false)
 
 Reads VASP output files required for DFT-raMO from the given directory. If no directory is given,
 the current directory is checked.
     
 If `CONTCAR` is set to true, the CONTCAR file will be used instead of the POSCAR.
 """
-function raMOInput(directory, ::FromVASP; CONTCAR = false)
-    return raMOInput(
+function raMODFTData(directory, ::FromVASP; CONTCAR = false)
+    return raMODFTData(
         joinpath(directory, CONTCAR ? "CONTCAR" : "POSCAR"),
         joinpath(directory, "WAVECAR"),
         joinpath(directory, "KPOINTS"),
@@ -107,4 +107,4 @@ function raMOInput(directory, ::FromVASP; CONTCAR = false)
     )
 end
 
-raMOInput(::FromVASP; CONTCAR) = raMOInput(".", FromVASP(); CONTCAR)
+raMODFTData(::FromVASP; CONTCAR) = raMODFTData(".", FromVASP(); CONTCAR)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -440,7 +440,7 @@ function read_yaml(io::IO)
         @sprintf("Maximum energy: %.3f Ha (%.3f eV)\n", emax, emax * Electrum.HARTREE2EV)
     )
     # Get runs
-    runs = get(data, "runs", nothing)
+    runs = get(yaml, "runs", nothing)
     @info "Performing $(length(runs)) runs."
     runlist = parse_runs(runs, dftinfo)
     return raMOInput(dftinfo, runlist, emin, emax, checkpoint, auto_psphere)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -443,8 +443,7 @@ function read_yaml(io::IO)
     runs = get(data, "runs", nothing)
     @info "Performing $(length(runs)) runs."
     runlist = parse_runs(runs, dftinfo)
-    # TODO: convert to a struct
-    return (runlist, checkpoint, auto_psphere, dftinfo, emin, emax)
+    return raMORuns(dftinfo, runlist, emin, emax, checkpoint, auto_psphere)
 end
 
 read_yaml(file) = open(read_yaml, file)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -443,7 +443,7 @@ function read_yaml(io::IO)
     runs = get(data, "runs", nothing)
     @info "Performing $(length(runs)) runs."
     runlist = parse_runs(runs, dftinfo)
-    return raMORuns(dftinfo, runlist, emin, emax, checkpoint, auto_psphere)
+    return raMOInput(dftinfo, runlist, emin, emax, checkpoint, auto_psphere)
 end
 
 read_yaml(file) = open(read_yaml, file)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -404,7 +404,7 @@ function read_yaml(io::IO)
     yaml = YAML.load(io)
     path = haskey(yaml, "path") ? yaml["path"] : "."
     origin = InputOrigin{Symbol(yaml["software"])}()
-    dftinfo = raMOInput(path, origin)
+    dftinfo = raMODFTData(path, origin)
     checkpoint = get(yaml, "checkpoint", nothing)
     # Check for empty string for robustness
     if isnothing(checkpoint) || isempty(checkpoint)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -5,15 +5,15 @@ Automatically runs DFTraMO from a configuration yaml file.
 """
 function dftramo_run(filename::AbstractString)
     ramoinput = read_yaml(filename)
-    occ_states = get_occupied_states(Electrum.PlanewaveWavefunction(ramoinput), ramoinput.emin, ramoinput.emax)
-    super = Supercell(Electrum.supercell(ramoinput), ORB_DICT)
+    occ_states = get_occupied_states(ramoinput)
+    super = Supercell(supercell(ramoinput), ORB_DICT)
     S = make_overlap_mat(occ_states)
     H = generate_H(super, DFTRAMO_EHT_PARAMS)
     
     if !isnothing(ramoinput.checkpoint) && length(ramoinput.checkpoint) > 0
         (psi_previous, num_electrons_left, num_raMO) = import_checkpoint(ramoinput.checkpoint)
     else
-        num_electrons_left = sum([get(E_DICT, n.atom.name, 0) for n in Electrum.PeriodicAtomList(Electrum.Crystal(ramoinput))])
+        num_electrons_left = sum([get(E_DICT, n.atom.name, 0) for n in PeriodicAtomList(ramoinput)])
         num_raMO = 0
         psi_previous = diagm(ones(size(occ_states.coeff)[2]))
         psi_previous = ComplexF32.(repeat(psi_previous, 1, 1, 2)) #spin states to be implemented
@@ -35,9 +35,9 @@ function dftramo_run(filename::AbstractString)
             r.name,
             DFTRAMO_EHT_PARAMS,
             occ_states,
-            Electrum.basis(ramoinput),
+            basis(ramoinput),
             kptmesh(raMODFTData(ramoinput)),
-            length.(collect.(Electrum.PlanewaveWavefunction(ramoinput).grange)),
+            length.(collect.(PlanewaveWavefunction(ramoinput).grange)),
             psi_previous,
             S,
             H,
@@ -55,9 +55,9 @@ function dftramo_run(filename::AbstractString)
             r.name,
             DFTRAMO_EHT_PARAMS,
             occ_states,
-            Electrum.basis(ramoinput),
+            basis(ramoinput),
             kptmesh(raMODFTData(ramoinput)),
-            length.(collect.(Electrum.PlanewaveWavefunction(ramoinput).grange)),
+            length.(collect.(PlanewaveWavefunction(ramoinput).grange)),
             psi_previous,
             S,
             H,
@@ -86,9 +86,9 @@ function dftramo_run(filename::AbstractString)
             r.name,
             DFTRAMO_EHT_PARAMS,
             occ_states,
-            Electrum.basis(ramoinput),
+            basis(ramoinput),
             kptmesh(raMODFTData(ramoinput)),
-            length.(collect.(Electrum.PlanewaveWavefunction(ramoinput).grange)),
+            length.(collect.(PlanewaveWavefunction(ramoinput).grange)),
             psi_previous,
             S,
             H,

--- a/test/input/ScAl3.yaml
+++ b/test/input/ScAl3.yaml
@@ -2,6 +2,7 @@ checkpoint:
 auto_psphere: true
 emin: -100 eV
 emax: 0.25 Ha
+software: vasp
 runs:
   - name: 1_Sc-Sc
     type: sp

--- a/test/inputs.jl
+++ b/test/inputs.jl
@@ -1,9 +1,9 @@
 @testset "Inputs" begin
     cd("input/") do
-        (runs, checkpoint, auto_psphere, dftinfo, emin, emax) = read_run_yaml("ScAl3.yaml")
-        @test length(runs) == 5
-        @test emin == -100*DFTraMO.Electrum.EV2HARTREE
-        @test emax == 0.25
+        ramoinput = read_yaml("ScAl3.yaml")
+        @test length(ramoinput.runlist) == 5
+        @test ramoinput.emin == -100*DFTraMO.Electrum.EV2HARTREE
+        @test ramoinput.emax == 0.25
     end
 
     @test DFTraMO.parse_sites(["10", "10", "10:2:16"]) == [10, 12, 14, 16]


### PR DESCRIPTION
Updated functions with references to new `raMODFTData` and `raMOInput` structs. On the UI end, not much changes, except now the keyword `software` is required for all YAML files.