### PR TITLE
Promoted old method since fix removes phase

### DIFF
--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -57,13 +57,13 @@ function raMO_to_density(
         phase = [exp(2*pi*im*r) for r in kr]
         isosurf .+= u.*phase
     end
-    #==isosurf = vec(isosurf)
+    isosurf = vec(isosurf)
     realimag = hcat(real(isosurf), imag(isosurf))
     (evalue, evec) = eigen(realimag'*realimag)
     isosurf *= complex(evec[2], evec[1])
     isosurf = reshape(ComplexF64.(isosurf), Tuple(real_gridsize))
-    return isosurf==#
-    return abs2.(isosurf)
+    return isosurf
+    #return abs2.(isosurf)
 end
 
 """


### PR DESCRIPTION
I am returning old lines of code in `raMO_to_density`. It turns out that the lines of code we thought were redundant were not. They implement the phase of orbitals. I am going to push these changes immediately, since they are important, but the branch should be kept open so we can find a more efficient method.