### PR TITLE
Discard ramo

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -272,6 +272,7 @@ Electrum.supercell(x::raMOInput) = supercell(x.dftdata)
 # Size and indexing depend on the run list.
 Base.size(x::raMOInput) = size(x.runlist)
 Base.getindex(x::raMOInput, i) = x.runlist[i]
+Base.iterate(x::raMOInput, i=1) = i > length(x.runlist) ? nothing : (x.runlist[i], i+1)
 
 """
     Supercell(atomlist::Atomlist{3}, orblist_by_type::Dict{String,Int64})

--- a/src/data.jl
+++ b/src/data.jl
@@ -299,3 +299,14 @@ end
 Electrum.basis(s::Supercell) = basis(s.atomlist)
 Electrum.PeriodicAtomList(s::Supercell) = s.atomlist
 Base.getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
+
+mutable struct raMOStatus
+   num_electrons_left::Int64
+   num_raMO::Int64
+   psi_previous::Array{ComplexF32}
+   num_run::Int64
+   const ramoinput::raMOInput
+   const occ_states::OccupiedStates
+   const H::Matrix{Float64}
+   const S::Matrix{ComplexF32}
+end

--- a/src/data.jl
+++ b/src/data.jl
@@ -281,8 +281,9 @@ Returns a supercell struct AtomList{3} and a Vector{Int} with number of orbitals
 struct Supercell
     atomlist::PeriodicAtomList{3}
     orbitals::Vector{Int}
-    function Supercell(atomlist::PeriodicAtomList{3}, orblist_by_type::Dict{String,Int64})
+    function Supercell(ramoinput::raMOInput, orblist_by_type::Dict{String,Int64})
         orbitals = Vector{Int}(undef,0)
+        atomlist = supercell(ramoinput)
         for atom in atomlist
             if !haskey(orblist_by_type, name(atom))
                 error("Number of orbitals for atom", name(atom),"cannot be found.")

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -57,13 +57,13 @@ function raMO_to_density(
         phase = [exp(2*pi*im*r) for r in kr]
         isosurf .+= u.*phase
     end
-    #==isosurf = vec(isosurf)
+    isosurf = vec(isosurf)
     realimag = hcat(real(isosurf), imag(isosurf))
     (evalue, evec) = eigen(realimag'*realimag)
     isosurf *= complex(evec[2], evec[1])
     isosurf = reshape(ComplexF64.(isosurf), Tuple(real_gridsize))
-    return isosurf==#
-    return abs2.(isosurf)
+    return isosurf
+    #return abs2.(isosurf)
 end
 
 """

--- a/src/raMO.jl
+++ b/src/raMO.jl
@@ -65,28 +65,23 @@ end
 
 The guts of DFTraMO.
 """
-# TODO: explain what all the arguments are
-# For now, will not use the raMOSystemStatus struct. This will be a to-do to clean up the code!
 function reconstruct_targets_DFT(
     psi_target::AbstractArray{<:Real},  # array dimensionality?
-    num_electrons_left::Integer,
-    run_name::AbstractString,
-    super::Supercell,
     ehtparams::ehtParams,
-    occ_states::OccupiedStates,
-    cell::RealBasis{3},                 # TODO: change to AbstractBasis on next Electrum release
-    kpt::AbstractVector{<:Integer},
-    psi_previous::Array{<:Number},      # array dimensionality?
-    S_original::Matrix{<:Number},
-    H::Matrix{<:Number},
-    # TODO: could these be keyword arguments? and can we remove use_prev?
-    use_prev::Bool,
-    prev_mat::AbstractString="",
+    ramostatus::raMOStatus
 )
-    
+    ramoinput = ramostatus.ramoinput
+    super = Supercell(ramoinput, ORB_DICT)
+    occ_states = ramostatus.occ_states
+    cell = basis(ramoinput)
+    kpt = kptmesh(raMODFTData(ramoinput))
+    psi_previous = ramostatus.psi_previous
+    S_original = ramostatus.S
+    H = ramostatus.H
+
     # Single target run or multiple targets
     num_targets = length(size(psi_target))
-    num_electrons_left = num_electrons_left - 2*num_targets
+    num_electrons_left = ramostatus.num_electrons_left - 2*num_targets
     
     # Checks for spin states
     # num_spin_states = size(wavefxn.waves)[1]
@@ -104,7 +99,6 @@ function reconstruct_targets_DFT(
     current_orb = 1;
     overlap_target_occupied = zeros(ComplexF32, max(num_spin_up,num_spin_down), num_targets, num_spin_states)
 
-    # Not sure what's going on here just yet; still parsing matlab code (~ ln 852)
     E_mat = Vector{Float64}(undef,0)
     for i in 1:num_targets # Loop through targets
         for j in 1:length(super.atomlist) # loop through every atom

--- a/src/runs.jl
+++ b/src/runs.jl
@@ -3,157 +3,61 @@
 
 Loops and runs DFT-raMO/Psphere analysis on a set of sp-based targets.
 """
-function loop_target_cluster_sp(
-    super,
-    voids_list,
-    void_radius,
-    num_electrons_left,
-    num_raMO,
-    run_name,
-    ehtparams,
-    occ_states,
-    geo_basis,
-    kpt,
-    grange,
-    psi_previous,
-    S,
-    H,
-    rsphere,
-    discard
-)
-    # check to see which directory we're in
-    if split(pwd(),'/')[end] != run_name && !isdir(run_name)
-        mkdir(run_name)
-    end
-    cd(run_name) do
-        if !isempty(readdir())
-            @warn "Directory is not empty. Files will be deleted/overwritten."
-            for n in readdir()
-                rm(n, force=true)
-            end
-        end
-        psphere = Vector{Float64}(undef, size(voids_list))
-        remainders = Array{ComplexF32,1}(undef, 0)
-        iter = ProgressBar(1:length(voids_list), unit="raMOs")
-        for i in iter
-            target = make_target_cluster_sp(voids_list, void_radius, i, super)
-            (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, ehtparams, ramostatus)
-            isosurf = raMO_to_density(occ_states, psi_up, kpt, grange)
-            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf),super.atomlist.basis), voids_list[i], rsphere)
-            open(string(run_name, "_psphere_", rsphere, ".txt"), "a") do io
-                print_psphere_terminal(iter, num_raMO+i, psphere[i], voids_list[i], io)
-            end
-            # Check if we are in discard ramo mode
-            if discard
-                # print out raMO but not checkpoint
-                write_to_XSF(isosurf, super.atomlist, string(run_name, "_", i, ".xsf"))
-                open(string(run_name, "_", i, ".raMO"), "w") do io
-                    write(io, psi_up)
-                end
-            else
-                # update remainders and number of electrons left
-                psi_previous = psi_previous2; num_electrons_left = Int(num_electrons_left2)
-                output_files(run_name, num_electrons_left, num_raMO+i, super, isosurf, psi_previous, psi_up)
-            end
-            remainders = psi_previous
-        end
-        cd("..")
-        p = psphere_graph(psphere, num_raMO, rsphere); display(p)
-        low_psphere = psphere_eval(psphere, super, voids_list)
-        return (low_psphere, remainders, num_raMO+length(voids_list), num_electrons_left)
-    end
-end
-
-#=="""
-    loop_AO()
-
-Loops and runs DFT-raMO/Psphere analysis on a set of atomic orbital targets.
-"""
-function loop_AO(
-    super,
-    atom_list,
-    target_orbital,
-    num_electrons_left,
-    num_raMO,
-    run_name,
-    ehtparams,
-    occ_states,
-    geo_basis,
-    kpt,
-    grange,
-    psi_previous,
-    S,
-    H,
-    rsphere,
-    discard
-) ## MUTABLE STRUCT RECOMMENDED
-    # check to see which directory we're in
-    if split(pwd(),'/')[end] != run_name && !isdir(run_name)
-        mkdir(run_name)
-    end
-    cd(run_name) do 
-        # check to see if directory is empty. if not, send warning before deleting
-        # TODO: in case someone puts a file in there, just wipe the necessary files rather
-        # than wiping everything.
-        if !isempty(readdir())
-            @warn "Directory is not empty. Files will be deleted/overwritten."
-            for n in readdir()
-                rm(n, force=true)
-            end
-        end
-        psphere = Vector{Float64}(undef, size(atom_list))
-        remainders = Array{ComplexF32,1}(undef, 0) # TODO
-        iter = ProgressBar(eachindex(atom_list), unit="raMOs")
-        for i in iter
-            target = make_target_AO(atom_list[i], target_orbital, super)
-            (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(
-                target,
-                num_electrons_left,
-                run_name,
-                super,
-                ehtparams,
-                occ_states,
-                geo_basis,
-                kpt,
-                psi_previous,
-                S,
-                H,
-                false,
-                "",
-            )
-            isosurf = raMO_to_density(occ_states, psi_up, kpt, grange)
-            pos = Vector(basis(super) * Electrum.BOHR2ANG * super[atom_list[i]].pos)
-            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf),basis(super)), pos, rsphere)
-            open(string(run_name, "_psphere_", rsphere, ".txt"), "a") do io
-                print_psphere_terminal(iter, num_raMO+i, psphere[i], pos, io)
-            end
-            # Check if we are in discard ramo mode
-            if discard
-                # print out raMO but not checkpoint
-                write_to_XSF(isosurf, super.atomlist, string(run_name, "_", i, ".xsf"))
-                open(string(run_name, "_", i, ".raMO"), "w") do io
-                    write(io, psi_up)
-                end
-            else
-                # update remainders and number of electrons left
-                psi_previous = psi_previous2; num_electrons_left = Int(num_electrons_left2)
-                output_files(run_name, num_electrons_left, num_raMO+i, super, isosurf, psi_previous, psi_up)
-            end
-            remainders = psi_previous
-        end
-        cd("..")
-        p = psphere_graph(psphere, num_raMO, rsphere); display(p)
-        low_psphere = psphere_eval(psphere, super, atom_list)
-        return (low_psphere, remainders, num_raMO+length(atom_list), num_electrons_left)
-    end
-end==#
-
-function loop_AO(ramostatus::raMOStatus)
-    # check to see which directory we're in
+function loop_target_cluster_sp(ramostatus::raMOStatus, sites)
     n = ramostatus.num_run
     ramoinput = ramostatus.ramoinput
     run = ramoinput[n]
     super = Supercell(ramoinput, ORB_DICT)
+    # check to see which directory we're in
+    if split(pwd(),'/')[end] != run.name && !isdir(run.name)
+        mkdir(run.name)
+    end
+    cd(run.name) do
+        if !isempty(readdir())
+            @warn "Directory is not empty. Files will be deleted/overwritten."
+            for n in readdir()
+                rm(n, force=true)
+            end
+        end
+        psphere = Vector{Float64}(undef, size(sites))
+        remainders = Array{ComplexF32,1}(undef, 0)
+        iter = ProgressBar(1:length(sites), unit="raMOs")
+        for i in iter
+            target = make_target_cluster_sp(sites, run.radius, i, super)
+            (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, DFTRAMO_EHT_PARAMS, ramostatus)
+            isosurf = raMO_to_density(ramostatus.occ_states, psi_up, kptmesh(raMODFTData(ramoinput)), length.(collect.(PlanewaveWavefunction(ramoinput).grange)))
+            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf), basis(super)), sites[i], run.rsphere)
+            open(string(run.name, "_psphere_", run.rsphere, ".txt"), "a") do io
+                print_psphere_terminal(iter, ramostatus.num_raMO+i, psphere[i], sites[i], io)
+            end
+            # Check if we are in discard ramo mode
+            if ramoinput.discard
+                # print out raMO but not checkpoint
+                write_to_XSF(isosurf, super.atomlist, string(run.name, "_", i, ".xsf"))
+                open(string(run.name, "_", i, ".raMO"), "w") do io
+                    write(io, psi_up)
+                end
+            else
+                # update remainders and number of electrons left
+                ramostatus.psi_previous = psi_previous2
+                ramostatus.num_electrons_left = Int(num_electrons_left2)
+                output_files(run.name, ramostatus.num_electrons_left, ramostatus.num_raMO+i, super, isosurf, ramostatus.psi_previous, psi_up)
+            end
+            remainders = ramostatus.psi_previous
+        end
+        cd("..")
+        p = psphere_graph(psphere, ramostatus.num_raMO, run.rsphere); display(p)
+        low_psphere = psphere_eval(psphere, super, sites)
+        return (low_psphere, remainders, ramostatus.num_raMO+length(sites), ramostatus.num_electrons_left)
+    end
+end
+
+function loop_AO(ramostatus::raMOStatus)
+    n = ramostatus.num_run
+    ramoinput = ramostatus.ramoinput
+    run = ramoinput[n]
+    super = Supercell(ramoinput, ORB_DICT)
+    # check to see which directory we're in
     if split(pwd(),'/')[end] != run.name && !isdir(run.name)
         mkdir(run.name)
     end
@@ -175,7 +79,7 @@ function loop_AO(ramostatus::raMOStatus)
             (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, DFTRAMO_EHT_PARAMS, ramostatus)
             isosurf = raMO_to_density(ramostatus.occ_states, psi_up, kptmesh(raMODFTData(ramoinput)), length.(collect.(PlanewaveWavefunction(ramoinput).grange)))
             pos = Vector(basis(super) * Electrum.BOHR2ANG * super[run.sites[i]].pos)
-            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf),basis(super)), pos, run.rsphere)
+            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf), basis(super)), pos, run.rsphere)
             open(string(run.name, "_psphere_", run.rsphere, ".txt"), "a") do io
                 print_psphere_terminal(iter, ramostatus.num_raMO+i, psphere[i], pos, io)
             end
@@ -192,11 +96,12 @@ function loop_AO(ramostatus::raMOStatus)
                 ramostatus.num_electrons_left = Int(num_electrons_left2)
                 output_files(run.name, ramostatus.num_electrons_left, ramostatus.num_raMO+i, super, isosurf, ramostatus.psi_previous, psi_up)
             end
+            remainders = ramostatus.psi_previous
         end
         cd("..")
         p = psphere_graph(psphere, ramostatus.num_raMO, run.rsphere); display(p)
         low_psphere = psphere_eval(psphere, super, run.sites)
-        return (low_psphere, remainders, ramostatus.num_raMO+length(run.sites), num_electrons_left)
+        return (low_psphere, remainders, ramostatus.num_raMO+length(run.sites), ramostatus.num_electrons_left)
     end
 end
 
@@ -205,29 +110,29 @@ end
 
 Loops and runs DFT-raMO/Psphere analysis on a set of LCAO targets.
 """
-function loop_LCAO(
-    super,
-    site_list, #atom_list,
-    target_orbital,
-    num_electrons_left,
-    num_raMO,
-    run_name,
-    ehtparams,
-    occ_states,
-    geo_basis,
-    kpt,
-    grange,
-    psi_previous,
-    S,
-    H,
-    rsphere,
-    discard
-)
-    # check to see which directory we're in
-    if split(pwd(),'/')[end] != run_name && !isdir(run_name)
-        mkdir(run_name)
+function loop_LCAO(ramostatus::raMOStatus)
+    n = ramostatus.num_run
+    ramoinput = ramostatus.ramoinput
+    run = ramoinput[n]
+    super = Supercell(ramoinput, ORB_DICT)
+    lcao_yaml = YAML.load_file(run.site_file)
+    target_orbital = get(lcao_yaml, "target", nothing)
+    isnothing(target_orbital) && error("Target cannot be blank for SALCs")
+    for t in target_orbital
+        !issubset(keys(t), keys(AO_RUNS)) && error("Target does not contain atomic orbitals. Please check.")
     end
-    cd(run_name) do 
+    site_list = get(lcao_yaml, "lcao", nothing)
+    if isa(site_list, Vector{Vector{Int}})
+        for n in site_list
+            # TODO check the num atoms in lcao list match num targets
+            length(n) != length(target_orbital) && error("Mismatch between length of LCAO ", n, " and specified target.")
+        end
+    end
+    # check to see which directory we're in
+    if split(pwd(),'/')[end] != run.name && !isdir(run.name)
+        mkdir(run.name)
+    end
+    cd(run.name) do 
         if !isempty(readdir())
             @warn "Directory is not empty. Files will be deleted/overwritten."
             for n in readdir()
@@ -239,30 +144,31 @@ function loop_LCAO(
         iter = ProgressBar(1:length(site_list), unit="raMOs")
         for i in iter
             target = make_target_lcao(site_list[i], target_orbital, super)
-            (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, ehtparams, ramostatus)
-            isosurf = raMO_to_density(occ_states, psi_up, kpt, grange)
-            pos = super.atomlist.basis*mp_lcao(site_list[i], super.atomlist)*Electrum.BOHR2ANG
-            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf),super.atomlist.basis), pos, rsphere)
-            open(string(run_name, "_psphere_", rsphere, ".txt"), "a") do io
-                print_psphere_terminal(iter, num_raMO+i, psphere[i], pos, io)
+            (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, DFTRAMO_EHT_PARAMS, ramostatus)
+            isosurf = raMO_to_density(ramostatus.occ_states, psi_up, kptmesh(raMODFTData(ramoinput)), length.(collect.(PlanewaveWavefunction(ramoinput).grange)))
+            pos = basis(super)*mp_lcao(site_list[i], PeriodicAtomList(super))*Electrum.BOHR2ANG
+            (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf), basis(super)), pos, run.rsphere)
+            open(string(run.name, "_psphere_", run.rsphere, ".txt"), "a") do io
+                print_psphere_terminal(iter, ramostatus.num_raMO+i, psphere[i], pos, io)
             end
             # Check if we are in discard ramo mode
-            if discard
+            if ramoinput.discard
                 # print out raMO but not checkpoint
-                write_to_XSF(isosurf, super.atomlist, string(run_name, "_", i, ".xsf"))
-                open(string(run_name, "_", i, ".raMO"), "w") do io
+                write_to_XSF(isosurf, super.atomlist, string(run.name, "_", i, ".xsf"))
+                open(string(run.name, "_", i, ".raMO"), "w") do io
                     write(io, psi_up)
                 end
             else
                 # update remainders and number of electrons left
-                psi_previous = psi_previous2; num_electrons_left = Int(num_electrons_left2)
-                output_files(run_name, num_electrons_left, num_raMO+i, super, isosurf, psi_previous, psi_up)
+                ramostatus.psi_previous = psi_previous2
+                ramostatus.num_electrons_left = Int(num_electrons_left2)
+                output_files(run.name, ramostatus.num_electrons_left, ramostatus.num_raMO+i, super, isosurf, ramostatus.psi_previous, psi_up)
             end
-            remainders = psi_previous
+            remainders = ramostatus.psi_previous
         end
         cd("..")
-        p = psphere_graph(psphere, num_raMO, rsphere); display(p)
+        p = psphere_graph(psphere, ramostatus.num_raMO, run.rsphere); display(p)
         low_psphere = psphere_eval(psphere, super, site_list)
-        return (low_psphere, remainders, num_raMO+length(site_list), num_electrons_left)
+        return (low_psphere, remainders, ramostatus.num_raMO+length(site_list), ramostatus.num_electrons_left)
     end
 end

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -41,7 +41,8 @@ function dftramo_run(filename::AbstractString)
             psi_previous,
             S,
             H,
-            r.rsphere
+            r.rsphere,
+            ramoinput.discard
             )
             site_list = r.sites # necessary for auto_psphere
         elseif r.type in CAGE_RUNS
@@ -61,7 +62,8 @@ function dftramo_run(filename::AbstractString)
             psi_previous,
             S,
             H,
-            r.rsphere
+            r.rsphere,
+            ramoinput.discard
             )
         elseif r.type == "lcao"
             lcao_yaml = YAML.load_file(r.site_file)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -19,15 +19,27 @@ function dftramo_run(filename::AbstractString)
         psi_previous = ComplexF32.(repeat(psi_previous, 1, 1, 2)) #spin states to be implemented
     end
     
+    ramostatus = raMOStatus(
+        num_electrons_left,
+        num_raMO,
+        psi_previous,
+        0,
+        ramoinput,
+        occ_states,
+        H,
+        S
+    )
+
     low_psphere = Vector{Int}(undef, 0)
     next = iterate(ramoinput)
     while next!==nothing
         (r, state) = next
+        ramostatus.num_run = state-1
         # print run information
         println(crayon"bold", "Run: ", crayon"light_cyan", r.name, crayon"!bold default")
         if r.type in keys(AO_RUNS)
-            (low_psphere, psi_previous2, num_raMO2, num_electrons_left2) = loop_AO(
-            super,
+            (low_psphere, psi_previous2, num_raMO2, num_electrons_left2) = loop_AO(ramostatus)
+            #==super,
             r.sites,
             get(AO_RUNS, r.type, 0),
             num_electrons_left,
@@ -43,7 +55,7 @@ function dftramo_run(filename::AbstractString)
             H,
             r.rsphere,
             ramoinput.discard
-            )
+            )==#
             site_list = r.sites # necessary for auto_psphere
         elseif r.type in CAGE_RUNS
             site_list = read_site_list(r.site_file)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -94,7 +94,8 @@ function dftramo_run(filename::AbstractString)
             psi_previous,
             S,
             H,
-            r.rsphere
+            r.rsphere,
+            discard
             )
         end
         ## If discard is enabled, print output files but discard functions and return to basis.


### PR DESCRIPTION
The new `discard` key for the YAML file now allows you to generate raMOs and return the functions to the original basis set. No `.chkpt` file is printed in this mode.

In addition, the `raMOStatus` struct is added to organize arguments for the functions in `runs.jl`. There is still a more optimization and refactoring to be done here, which can be done in a more appropriately-titled branch.