### PR TITLE
Fix/electron ct

### DIFF
--- a/src/Psphere.jl
+++ b/src/Psphere.jl
@@ -45,30 +45,18 @@ function Psphere(
 end
 
 """
-    psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site_list)
+    psphere_eval(psphere::AbstractVector{<:Real}, site::AbstractVector{SVector{3, Float64}})
     
 Prints Psphere analysis to the terminal.
 """
-function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site_list::AbstractVector{Int})
-    m = maximum(psphere)
-    a = findall(x->x<0.15*m, psphere)
-    if !isempty(a)
-        println("The following atoms have Pspheres <15% of the maximum (", m, "):")
-        for n in a
-            site = Vector(super.atomlist.basis*Electrum.BOHR2ANG*super.atomlist[site_list[n]].pos)
-            println("Atom ", site_list[n], ": ", @sprintf("Psphere: %.3f", psphere[n]), @sprintf(" at site [%.3f, %.3f, %.3f]", site[1], site[2], site[3]))
-        end
-    end
-    return a
-end
 
-function psphere_eval(psphere::AbstractVector{<:Real}, site::AbstractVector{AbstractVector{<:Real}})
+function psphere_eval(psphere::AbstractVector{<:Real}, site::AbstractVector{SVector{3, Float64}})
     m = maximum(psphere)
     a = findall(x->x<0.15*m, psphere)
     if !isempty(a)
         println("The following sites have Pspheres <15% of the maximum (", m, "):")
         for n in a
-            println("Site ", n, ": ", @sprintf("Psphere: %.3f", psphere[n]), @sprintf(" at site [%.3f, %.3f, %.3f]", site[1], site[2], site[3]))
+            println("Site ", n, ": ", @sprintf("Psphere: %.3f", psphere[n]), @sprintf(" at site [%.3f, %.3f, %.3f]", site[n][1], site[n][2], site[n][3]))
         end
     end
     return a

--- a/src/Psphere.jl
+++ b/src/Psphere.jl
@@ -62,7 +62,7 @@ function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site_li
     return a
 end
 
-function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site::AbstractVector{AbstractVector{<:Real}})
+function psphere_eval(psphere::AbstractVector{<:Real}, site::AbstractVector{AbstractVector{<:Real}})
     m = maximum(psphere)
     a = findall(x->x<0.15*m, psphere)
     if !isempty(a)

--- a/src/Psphere.jl
+++ b/src/Psphere.jl
@@ -49,7 +49,7 @@ end
     
 Prints Psphere analysis to the terminal.
 """
-function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site_list)
+function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site_list::AbstractVector{Int})
     m = maximum(psphere)
     a = findall(x->x<0.15*m, psphere)
     if !isempty(a)
@@ -57,6 +57,18 @@ function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site_li
         for n in a
             site = Vector(super.atomlist.basis*Electrum.BOHR2ANG*super.atomlist[site_list[n]].pos)
             println("Atom ", site_list[n], ": ", @sprintf("Psphere: %.3f", psphere[n]), @sprintf(" at site [%.3f, %.3f, %.3f]", site[1], site[2], site[3]))
+        end
+    end
+    return a
+end
+
+function psphere_eval(psphere::AbstractVector{<:Real}, super::Supercell, site::AbstractVector{AbstractVector{<:Real}})
+    m = maximum(psphere)
+    a = findall(x->x<0.15*m, psphere)
+    if !isempty(a)
+        println("The following sites have Pspheres <15% of the maximum (", m, "):")
+        for n in a
+            println("Site ", n, ": ", @sprintf("Psphere: %.3f", psphere[n]), @sprintf(" at site [%.3f, %.3f, %.3f]", site[1], site[2], site[3]))
         end
     end
     return a

--- a/src/data.jl
+++ b/src/data.jl
@@ -196,6 +196,8 @@ struct OccupiedStates
     end
 end
 
+num_states(x::OccupiedStates) = size(x.coeff)[2]
+
 """
     raMOInput
 

--- a/src/runs.jl
+++ b/src/runs.jl
@@ -1,5 +1,5 @@
 """
-    loop_target_cluster_sp()
+loop_target_cluster_sp()
 
 Loops and runs DFT-raMO/Psphere analysis on a set of sp-based targets.
 """
@@ -23,6 +23,10 @@ function loop_target_cluster_sp(ramostatus::raMOStatus, sites)
         remainders = Array{ComplexF32,1}(undef, 0)
         iter = ProgressBar(1:length(sites), unit="raMOs")
         for i in iter
+            # check to see if we have electrons left
+            if size(ramostatus.psi_previous)[2] == 0
+                break
+            end
             target = make_target_cluster_sp(sites, run.radius, i, super)
             (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, DFTRAMO_EHT_PARAMS, ramostatus)
             isosurf = raMO_to_density(ramostatus.occ_states, psi_up, kptmesh(raMODFTData(ramoinput)), length.(collect.(PlanewaveWavefunction(ramoinput).grange)))
@@ -75,6 +79,10 @@ function loop_AO(ramostatus::raMOStatus)
         remainders = Array{ComplexF32,1}(undef, 0) # TODO
         iter = ProgressBar(eachindex(run.sites), unit="raMOs")
         for i in iter
+            # check to see if we have electrons left
+            if size(ramostatus.psi_previous)[2] == 0
+                break
+            end
             target = make_target_AO(run.sites[i], get(AO_RUNS, run.type, 0), super)
             (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, DFTRAMO_EHT_PARAMS, ramostatus)
             isosurf = raMO_to_density(ramostatus.occ_states, psi_up, kptmesh(raMODFTData(ramoinput)), length.(collect.(PlanewaveWavefunction(ramoinput).grange)))
@@ -106,7 +114,7 @@ function loop_AO(ramostatus::raMOStatus)
 end
 
 """
-    loop_LCAO()
+loop_LCAO()
 
 Loops and runs DFT-raMO/Psphere analysis on a set of LCAO targets.
 """
@@ -143,6 +151,10 @@ function loop_LCAO(ramostatus::raMOStatus)
         remainders = Array{ComplexF32,1}(undef, 0)
         iter = ProgressBar(1:length(site_list), unit="raMOs")
         for i in iter
+            # check to see if we have electrons left
+            if size(ramostatus.psi_previous)[2] == 0
+                break
+            end
             target = make_target_lcao(site_list[i], target_orbital, super)
             (psi_previous2, psi_up, e_up, num_electrons_left2) = reconstruct_targets_DFT(target, DFTRAMO_EHT_PARAMS, ramostatus)
             isosurf = raMO_to_density(ramostatus.occ_states, psi_up, kptmesh(raMODFTData(ramoinput)), length.(collect.(PlanewaveWavefunction(ramoinput).grange)))
@@ -166,7 +178,6 @@ function loop_LCAO(ramostatus::raMOStatus)
             end
             remainders = ramostatus.psi_previous
         end
-        cd("..")
         p = psphere_graph(psphere, ramostatus.num_raMO, run.rsphere); display(p)
         low_psphere = psphere_eval(psphere, super, site_list)
         return (low_psphere, remainders, ramostatus.num_raMO+length(site_list), ramostatus.num_electrons_left)

--- a/src/runs.jl
+++ b/src/runs.jl
@@ -108,7 +108,9 @@ function loop_AO(ramostatus::raMOStatus)
         end
         cd("..")
         p = psphere_graph(psphere, ramostatus.num_raMO, run.rsphere); display(p)
-        low_psphere = psphere_eval(psphere, super, run.sites)
+        # convert sites into cartesian; filter out atomic sites
+        sites = [basis(super)*Electrum.BOHR2ANG*i.pos for i in PeriodicAtomList(super)][run.sites]
+        low_psphere = psphere_eval(psphere, sites)
         return (low_psphere, remainders, ramostatus.num_raMO+length(run.sites), ramostatus.num_electrons_left)
     end
 end

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -14,6 +14,11 @@ function dftramo_run(filename::AbstractString)
         (psi_previous, num_electrons_left, num_raMO) = import_checkpoint(ramoinput.checkpoint)
     else
         num_electrons_left = sum([get(E_DICT, n.atom.name, 0) for n in PeriodicAtomList(super)])
+        if !isequal(num_electrons_left/2, num_states(occ_states))
+            x = num_states(occ_states)
+            y = num_electrons_left/2
+            @warn "The number of occupied states $x does not match with the number of electrons $num_electrons_left ($y states) calculated. Consider adjusting your energy range."
+        end
         num_raMO = 0
         psi_previous = diagm(ones(size(occ_states.coeff)[2]))
         psi_previous = ComplexF32.(repeat(psi_previous, 1, 1, 2)) #spin states to be implemented

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -35,6 +35,7 @@ function dftramo_run(filename::AbstractString)
         S
     )
 
+    aps = ""
     low_psphere = Vector{Int}(undef, 0)
     next = iterate(ramoinput)
     while next!==nothing
@@ -46,7 +47,7 @@ function dftramo_run(filename::AbstractString)
             break
         end
         # print run information
-        println(crayon"bold", "Run: ", crayon"light_cyan", r.name, crayon"!bold default")
+        println(crayon"bold", "Run: ", crayon"light_cyan", string(r.name, aps), crayon"!bold default")
         if r.type in keys(AO_RUNS)
             (low_psphere, psi_previous2, num_raMO2, num_electrons_left2) = loop_AO(ramostatus)
             site_list = r.sites # necessary for auto_psphere
@@ -71,8 +72,9 @@ function dftramo_run(filename::AbstractString)
             e = num_electrons_left - (low_psphere[1]-1)*2
             raMO = num_raMO + (low_psphere[1]-1)
             (psi_previous, num_electrons_left, num_raMO) = import_checkpoint(string(r.name, "/", r.name, "_", raMO, "_", e, ".chkpt"))
+            aps = ""
             # If the last raMOs were the only ones with low_psphere, no need to rerun
-            isempty(site_list) ? next = iterate(ramoinput, state) : r.name = string(r.name, "_aps")
+            isempty(site_list) ? next = iterate(ramoinput, state) : aps = "_aps"
         else
             next = iterate(ramoinput, state)
             ramostatus.num_electrons_left = num_electrons_left2

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -40,6 +40,11 @@ function dftramo_run(filename::AbstractString)
     while next!==nothing
         (r, state) = next
         ramostatus.num_run = state-1
+        # check to see if we have electrons left
+        if size(ramostatus.psi_previous)[2] == 0
+            @info "No more states in the basis set. Stopping DFT-raMO."
+            break
+        end
         # print run information
         println(crayon"bold", "Run: ", crayon"light_cyan", r.name, crayon"!bold default")
         if r.type in keys(AO_RUNS)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -329,7 +329,7 @@ function read_yaml(io::IO)
     discard::Bool = get(yaml, "discard", false)
     @info "Discard option is " * (discard ? "en" : "dis") * "abled."
     # Use automatic conversion/type assertion for error
-    auto_psphere::Bool = get(yaml, "auto_sphere", false)
+    auto_psphere::Bool = get(yaml, "auto_psphere", false)
     if discard
         @info "Auto Psphere will be ignored."
     else


### PR DESCRIPTION
Addresses #37 

1. DFT-raMO now gives a warning (but does not stop) at the start of a fresh run (no checkpoint) when the number of states in the basis set (as determined by the energy range) does not match the number of electrons calculated from the atoms available in the supercell.
2. The program also now stops analysis when the basis set is empty (instead of throwing an error).
3. `psphere_eval` now has two methods and should now print sites correctly.