### PR TITLE
`OccupiedStates` constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,4 +35,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Test", "Electrum"]
+test = ["Test", "StaticArrays", "Electrum"]

--- a/Project.toml
+++ b/Project.toml
@@ -35,4 +35,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Electrum"]

--- a/src/data.jl
+++ b/src/data.jl
@@ -187,14 +187,12 @@ end
 KPoint(skb::SpinKPointBand{D}) = skb.kpt
 
 """
-    OccupiedStates(
-        coeff::AbstractMatrix{<:Number},
-        kpt::AbstractMatrix{<:AbstractVector},
-        G::AbstractMatrix{<:AbstractVector}
-    )
+    OccupiedStates{T<:Number} <: DenseMatrix{T}
 
-Returns an `OccupiedStates` struct. The coeff matrix is `num_occupied_states` by `num_occupied_pw`
-in dimensions, while kpt is `num_occupied_states` in length, and G is `num_occupied_pw` in length.
+Stores a representation of a wavefunction's states of interest. This representation is a matrix of
+coefficients, with the list of nonzero G-vectors `G` stored as a `Vector{SVector{3,Int}}` and the
+associated spin, k-point, and band data `skb` stored as a `Vector{DFTraMO.SpinKPointBand{3}}`. The 
+matrix has dimensions `length(G)` by `length(skb)` and can be indexed.
 """
 struct OccupiedStates{T<:Number} <: DenseMatrix{T}
     coeff::Matrix{T}
@@ -224,6 +222,13 @@ Base.setindex!(o::OccupiedStates, x, i...) = setindex!(o.coeff, x, i...)
 
 num_states(o::OccupiedStates) = length(o.skb)
 
+"""
+    OccupiedStates(wf::PlanewaveWavefunction; emin = min_energy(wf), emax = fermi(wf))
+    OccupiedStates(wf::raMODFTData; emin = min_energy(wf), emax = fermi(wf))
+
+Constructs an `OccupiedStates` using the wavefunction states with energies between `emin` and `emax`
+(inclusive).
+"""
 function OccupiedStates(wf::PlanewaveWavefunction; emin = min_energy(wf), emax = fermi(wf))
     selected_states = findall(emin .<= wf.energies .<= emax)
     # Find the range of occupied band/kpt/spin

--- a/src/data.jl
+++ b/src/data.jl
@@ -184,7 +184,7 @@ struct SpinKPointBand{D}
     band::Int
 end
 
-KPoint(skb::SpinKPointBand{D}) = skb.kpt
+Electrum.KPoint(skb::SpinKPointBand{D}) = skb.kpt
 
 """
     OccupiedStates{T<:Number} <: DenseMatrix{T}

--- a/src/data.jl
+++ b/src/data.jl
@@ -196,18 +196,26 @@ KPoint(skb::SpinKPointBand{D}) = skb.kpt
 Returns an `OccupiedStates` struct. The coeff matrix is `num_occupied_states` by `num_occupied_pw`
 in dimensions, while kpt is `num_occupied_states` in length, and G is `num_occupied_pw` in length.
 """
-struct OccupiedStates <: DenseMatrix{ComplexF32}
-    coeff::Matrix{ComplexF32}
+struct OccupiedStates{T<:Number} <: DenseMatrix{T}
+    coeff::Matrix{T}
     skb::Vector{SpinKPointBand{3}}
     G::Vector{SVector{3,Int}}
-    function OccupiedStates(
-        coeff::AbstractMatrix{<:Number},
+    function OccupiedStates{T}(
+        coeff::AbstractMatrix,
         skb::AbstractVector{SpinKPointBand{3}},
         G::AbstractVector{<:AbstractVector}
-    )
+    ) where T
         @assert size(coeff) === (length(G), length(skb)) "Incommensurate matrix dimensions"
         return new(coeff, skb, G)
     end
+end
+
+function OccupiedStates(
+    coeff::AbstractMatrix{T},
+    skb::AbstractVector{SpinKPointBand{3}},
+    g::AbstractVector{<:AbstractVector}
+) where T
+    return OccupiedStates{T}(coeff, skb, g)
 end
 
 Base.size(o::OccupiedStates) = size(o.coeff)

--- a/src/data.jl
+++ b/src/data.jl
@@ -241,7 +241,7 @@ function OccupiedStates(wf::PlanewaveWavefunction; emin = min_energy(wf), emax =
     return OccupiedStates(coeff, occ_skb, occ_gvecs)
 end
 
-OccupiedStates(x::raMODFTData; emin, emax) = OccupiedStates(x.wave; emin, emax)
+OccupiedStates(x::raMODFTData; emin, emax=x.fermi) = OccupiedStates(x.wave; emin, emax)
 
 """
     raMOInput

--- a/src/data.jl
+++ b/src/data.jl
@@ -184,7 +184,7 @@ struct SpinKPointBand{D}
     band::Int
 end
 
-Electrum.KPoint(skb::SpinKPointBand{D}) = skb.kpt
+Electrum.KPoint(skb::SpinKPointBand) = skb.kpt
 
 """
     OccupiedStates{T<:Number} <: DenseMatrix{T}

--- a/src/data.jl
+++ b/src/data.jl
@@ -183,7 +183,7 @@ Electrum.supercell(x::raMODFTData) = supercell(x.xtal.atoms, kptmesh(x))
 Returns an `OccupiedStates` struct. The coeff matrix is `num_occupied_states` by `num_occupied_pw`
 in dimensions, while kpt is `num_occupied_states` in length, and G is `num_occupied_pw` in length.
 """
-struct OccupiedStates
+struct OccupiedStates <: DenseMatrix{ComplexF32}
     coeff::Matrix{ComplexF32}
     kpt::Matrix{SVector{3, Float64}}
     G::Matrix{SVector{3, Int64}}
@@ -197,6 +197,9 @@ struct OccupiedStates
 end
 
 num_states(x::OccupiedStates) = size(x.coeff)[2]
+Base.size(o::OccupiedStates) = size(o.coeff)
+Base.getindex(o::OccupiedStates, i...) = getindex(o.coeff, i...)
+Base.setindex!(o::OccupiedStates, x, i...) = setindex!(o.coeff, x, i...)
 
 """
     raMOInput

--- a/src/data.jl
+++ b/src/data.jl
@@ -236,13 +236,14 @@ Constructs an `OccupiedStates` using the wavefunction states with energies betwe
 (inclusive).
 """
 function OccupiedStates(wf::PlanewaveWavefunction; emin = min_energy(wf), emax = fermi(wf))
+    # Find the range of occupied band/kpt/spin and collect that data
     selected_states = findall(emin .<= wf.energies .<= emax)
-    # Find the range of occupied band/kpt/spin
     occ_skb = [SpinKPointBand(wf.spins[s], wf.kpoints[k], b) for (b,k,s) in Tuple.(selected_states)]
     # occ_bands = findall(!iszero, sum.(eachslice(selected_states, dims=1)))
-    # Find all possible occupied planewaves
+    # Get indices for all G-vectors with nonzero coefficients and store the list of G-vectors
     occ_pw = findall(any.(!iszero, eachslice(wf.data, dims = 1)))
     occ_gvecs = SVector.(Tuple.(FFTBins(wf)[occ_pw]))
+    # Filter coefficients by valid G-vectors and states of interest
     coeff = @view(wf.data[occ_pw,:,:,:])[:,selected_states]
     return OccupiedStates(coeff, occ_skb, occ_gvecs)
 end

--- a/src/data.jl
+++ b/src/data.jl
@@ -203,7 +203,13 @@ struct OccupiedStates{T<:Number} <: DenseMatrix{T}
         skb::AbstractVector{SpinKPointBand{3}},
         G::AbstractVector{<:AbstractVector}
     ) where T
-        @assert size(coeff) === (length(G), length(skb)) "Incommensurate matrix dimensions"
+        @assert size(coeff, 1) == length(G) string(
+            "Number of G-vectors does not match the first dimension of the coefficient matrix."
+        )
+        @assert size(coeff, 2) == length(skb) string(
+            "Number of spins/kpoints/bands does not match the first dimension of the coefficient " *
+            "matrix."
+        )
         return new(coeff, skb, G)
     end
 end

--- a/src/data.jl
+++ b/src/data.jl
@@ -174,6 +174,19 @@ kptmesh(x::raMODFTData) = diag(x.xtal.transform)
 Electrum.supercell(x::raMODFTData) = supercell(x.xtal.atoms, kptmesh(x))
 
 """
+    SpinKPointBand{D}
+
+Stores a tuple of spin direction, k-point, and band in `D` dimensions.
+"""
+struct SpinKPointBand{D}
+    spin::SVector{D,Float64}
+    kpt::KPoint{D}
+    band::Int
+end
+
+KPoint(skb::SpinKPointBand{D}) = skb.kpt
+
+"""
     OccupiedStates(
         coeff::AbstractMatrix{<:Number},
         kpt::AbstractMatrix{<:AbstractVector},

--- a/src/data.jl
+++ b/src/data.jl
@@ -210,10 +210,11 @@ struct OccupiedStates <: DenseMatrix{ComplexF32}
     end
 end
 
-num_states(x::OccupiedStates) = size(x.coeff)[2]
 Base.size(o::OccupiedStates) = size(o.coeff)
 Base.getindex(o::OccupiedStates, i...) = getindex(o.coeff, i...)
 Base.setindex!(o::OccupiedStates, x, i...) = setindex!(o.coeff, x, i...)
+
+num_states(o::OccupiedStates) = length(o.skb)
 
 function OccupiedStates(wf::PlanewaveWavefunction; emin = min_energy(wf), emax = fermi(wf))
     selected_states = findall(emin .<= wf.energies .<= emax)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Electrum = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Electrum = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"

--- a/test/occupiedstates.jl
+++ b/test/occupiedstates.jl
@@ -1,4 +1,4 @@
-@testset OccupiedStates begin
+@testset "OccupiedStates" begin
     wf = readWAVECAR("input/WAVECAR")
     # Fermi energy is the maximum...obtain it separately
     emax = get_fermi("input/OUTCAR")[:fermi]

--- a/test/occupiedstates.jl
+++ b/test/occupiedstates.jl
@@ -1,0 +1,5 @@
+@testset OccupiedStates begin
+    wf = readWAVECAR("input/WAVECAR")
+    # Fermi energy is the maximum...obtain it separately
+    emax = get_fermi("input/OUTCAR")[:fermi]
+end

--- a/test/occupiedstates.jl
+++ b/test/occupiedstates.jl
@@ -2,4 +2,22 @@
     wf = readWAVECAR("input/WAVECAR")
     # Fermi energy is the maximum...obtain it separately
     emax = get_fermi("input/OUTCAR")[:fermi]
+    occ_states = OccupiedStates(wf, emin = min_energy(wf), emax = emax)
+    # There shouldn't be more G-vectors than the wavefunction bounds permit
+    @test size(occ_states, 1) <= prod(size(wf)[4:end])
+    @test size(occ_states, 1) == length(occ_states.G)
+    for g in occ_states.g
+        @test g in SVector.(Tuple.(FFTBins(wf)))
+    end
+    # Size of the second dimension depends on the energy range
+    @test size(occ_states, 2) == count(emin .<= wf.energies .<= emax)
+    @test size(occ_states, 2) == length(occ_states.skb)
+    # SpinKPointBand structs should return all relevant info from wavefunction
+    for x in occ_states.skb
+        @test x.spin in wf.spins
+        @test KPoint(x) in KPointMesh(wf)
+        @test x.band in axes(wf, 3)
+    end
+    # Not sure if encoding equality is worth doing
+    @test occ_states == OccupiedStates(wf, emax = emax)
 end

--- a/test/occupiedstates.jl
+++ b/test/occupiedstates.jl
@@ -6,7 +6,7 @@
     # There shouldn't be more G-vectors than the wavefunction bounds permit
     @test size(occ_states, 1) <= prod(size(wf)[4:end])
     @test size(occ_states, 1) == length(occ_states.G)
-    for g in occ_states.g
+    for g in occ_states.G
         @test g in SVector.(Tuple.(FFTBins(wf)))
     end
     # Size of the second dimension depends on the energy range

--- a/test/occupiedstates.jl
+++ b/test/occupiedstates.jl
@@ -1,6 +1,7 @@
 @testset "OccupiedStates" begin
     wf = readWAVECAR("input/WAVECAR")
     # Fermi energy is the maximum...obtain it separately
+    emin = min_energy(wf)
     emax = get_fermi("input/OUTCAR")[:fermi]
     occ_states = OccupiedStates(wf, emin = min_energy(wf), emax = emax)
     # There shouldn't be more G-vectors than the wavefunction bounds permit

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using Test
+using Electrum
 using DFTraMO
 
 @testset "All tests" begin
     # Add your tests here, ideally as file includes.
     include("inputs.jl")
+    include("occupiedstates.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using StaticArrays
 using Electrum
 using DFTraMO
 


### PR DESCRIPTION
This should _dramatically_ simplify the implementation of `OccupiedStates`, which is now a parametric type constructible from a `PlanewaveWavefunction`, `raMODFTData`, or `raMOInput`.

Some of the changes that have happened:
- `OccupiedStates` is now `OccupiedStates{T<:Number}` (usually `T<:Complex`).
- `OccupiedStates{T}` subtypes `DenseMatrix{T}` and has size, indexing, and assignment defined.
- It stores spin, k-point and band info as a new struct `SpinKPointBand{3}` which can be converted to a k-point with the `KPoint` constructor.
- It can be constructed from a `PlanewaveWavefunction{3}` or `raMODFTData` with optional energy parameters (it will make reasonable guesses - `emin` is the minimum energy in the wavefunction, `emax` is the result of `Electrum.fermi(::PlanewaveWavefunction)`, which guesses the Fermi energy from the occupancy), or from a `raMOInput` (which has the energy info provided automatically).