### PR TITLE
Refactor/loop mode

### DIFF
--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -19,15 +19,15 @@ generate_H, reconstruct_targets_DFT, N_L
 include("make_targets.jl")
 export make_target_AO, make_target_cluster_sp, make_target_hybrid
 
-include("runs.jl")
-export loop_target_cluster_sp, loop_AO, loop_LCAO
+#include("runs.jl")
+#export loop_target_cluster_sp, loop_AO, loop_LCAO
 
 include("inputs.jl")
 export import_VASP, import_abinit, get_occupied_states, read_eht_params, read_site_list, 
 import_checkpoint, import_raMO
 
 include("yaml.jl")
-export dftramo_run, parse_energy, parse_sites, read_yaml, dftramo_run2
+export dftramo_run, parse_energy, parse_sites, read_yaml
 
 include("outputs.jl")
 export write_to_XSF, raMO_to_density

--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -7,7 +7,7 @@ using ProgressBars, Crayons
 using Requires
 
 include("data.jl")
-export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMODFTData, raMOInput
+export OrbitalParams, ehtParams, Supercell, OccupiedStates, raMODFTData, raMOInput, raMOStatus
 
 include("software.jl")
 export InputOrigin, FromABINIT, FromVASP

--- a/src/DFTraMO.jl
+++ b/src/DFTraMO.jl
@@ -23,11 +23,11 @@ include("runs.jl")
 export loop_target_cluster_sp, loop_AO, loop_LCAO
 
 include("inputs.jl")
-export import_VASP, import_abinit,get_occupied_states, read_eht_params, read_site_list, 
+export import_VASP, import_abinit, get_occupied_states, read_eht_params, read_site_list, 
 import_checkpoint, import_raMO
 
 include("yaml.jl")
-export dftramo_run, parse_energy, parse_sites, read_yaml
+export dftramo_run, parse_energy, parse_sites, read_yaml, dftramo_run2
 
 include("outputs.jl")
 export write_to_XSF, raMO_to_density

--- a/src/data.jl
+++ b/src/data.jl
@@ -351,12 +351,35 @@ Electrum.PeriodicAtomList(s::Supercell) = s.atomlist
 Base.getindex(s::Supercell, i...) = getindex(s.atomlist, i...)
 
 mutable struct raMOStatus
-   num_electrons_left::Int64
-   num_raMO::Int64
-   psi_previous::Array{ComplexF32}
-   num_run::Int64
-   const ramoinput::raMOInput
-   const occ_states::OccupiedStates
-   const H::Matrix{Float64}
-   const S::Matrix{ComplexF32}
+    num_electrons_left::Int64
+    num_raMO::Int64
+    psi_previous::Array{ComplexF32}
+    num_run::Int64
+    const ramoinput::raMOInput
+    const occ_states::OccupiedStates
+    const H::Matrix{Float64}
+    const S::Matrix{ComplexF32}
+    const supercell::Supercell
+    function raMOStatus(ramoinput::raMOInput)
+        occ_states = OccupiedStates(ramoinput)
+        super = Supercell(ramoinput, ORB_DICT)
+        S = make_overlap_mat(occ_states)
+        H = generate_H(super, DFTRAMO_EHT_PARAMS)
+        if !isnothing(ramoinput.checkpoint) && length(ramoinput.checkpoint) > 0
+            (psi_previous, num_electrons_left, num_raMO) = import_checkpoint(ramoinput.checkpoint)
+        else
+            num_electrons_left = sum([get(E_DICT, n.atom.name, 0) for n in PeriodicAtomList(super)])
+            if !isequal(num_electrons_left/2, num_states(occ_states))
+                x = num_states(occ_states)
+                y = num_electrons_left/2
+                @warn "The number of occupied states $x does not match with the number of electrons $num_electrons_left ($y states) calculated. Consider adjusting your energy range."
+            end
+            num_raMO = 0
+            psi_previous = diagm(ones(size(occ_states.coeff)[2]))
+            psi_previous = ComplexF32.(repeat(psi_previous, 1, 1, 2)) #spin states to be implemented
+        end
+        return new(num_electrons_left, num_raMO, psi_previous, 0, ramoinput, occ_states, H, S, super)
+    end
 end
+
+Electrum.PeriodicAtomList(x::raMOStatus) = x.supercell.atomlist

--- a/src/data.jl
+++ b/src/data.jl
@@ -263,21 +263,17 @@ struct raMOInput
     emin::Float64
     emax::Float64
     checkpoint::String  # TODO: should we use some sort of IO type? or checkpoint container?
-    auto_psphere::Bool
-    discard::Bool
+    mode::String
     function raMOInput(
         dftdata::raMODFTData,
         runlist,
         emin::Real,
         emax::Real,
         checkpoint::AbstractString,
-        auto_psphere,
-        discard
+        mode::AbstractString
     )
         @assert emin < emax "Minimum energy is not less than maximum energy"
-        isnothing(auto_psphere) && (auto_psphere = false)
-        isnothing(discard) && (discard = false)
-        return new(dftdata, collect(runlist), emin, emax, checkpoint, auto_psphere, discard)
+        return new(dftdata, collect(runlist), emin, emax, checkpoint, mode)
     end
 end
 
@@ -306,13 +302,12 @@ If `emax` is unset, then the value is automatically set to the Fermi energy of t
 function raMOInput(
     dftdata::raMODFTData,
     runlist;
-    auto_psphere = false,
-    discard = false,
-    checkpoint::AbstractString = "",
     emin::Real = minimum(dftdata.wave.energies),
-    emax::Real = fermi(dftdata)
+    emax::Real = fermi(dftdata),
+    checkpoint::AbstractString = "",
+    mode::AbstractString = ""
 )
-    return raMOInput(dftdata, runlist, emin, emax, checkpoint, auto_psphere, discard)
+    return raMOInput(dftdata, runlist, emin, emax, checkpoint, mode)
 end
 
 raMODFTData(x::raMOInput) = x.dftdata

--- a/src/data.jl
+++ b/src/data.jl
@@ -383,3 +383,4 @@ mutable struct raMOStatus
 end
 
 Electrum.PeriodicAtomList(x::raMOStatus) = x.supercell.atomlist
+size_basis(x::raMOStatus) = size(x.psi_previous)[2]

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -29,11 +29,11 @@ function raMO_to_density(
     kpt,
     grange,
 )
-    reduced_kpt = unique(occ_states.kpt)
+    reduced_kpt = unique([k for k in KPoint.(occ_states.skb)])
     pw_raMO = Array{ComplexF32}(undef,size(occ_states.coeff)[1],length(reduced_kpt))
     for k in eachindex(reduced_kpt)
-        m = findfirst(x->x == reduced_kpt[k], occ_states.kpt[1,:])
-        n = findlast(x->x == reduced_kpt[k], occ_states.kpt[1,:])
+        m = findfirst(x->x == reduced_kpt[k], KPoint.(occ_states.skb))
+        n = findlast(x->x == reduced_kpt[k], KPoint.(occ_states.skb))
         pw_raMO[:,k] = occ_states.coeff[:,m:n]*psi[m:n]
     end
     gridsize = grange

--- a/src/raMO.jl
+++ b/src/raMO.jl
@@ -17,7 +17,7 @@ function make_overlap_mat(occ_states::OccupiedStates)
     S = occ_states.coeff'*occ_states.coeff
     
     # Get list of unique kpoints
-    kptlist = occ_states.kpt
+    kptlist = [skb.kpt for skb in occ_states.skb]
     u_kptlist = unique(kptlist)
 
     # Checks to see if kpoint matches for the occ_states matrix

--- a/src/raMO.jl
+++ b/src/raMO.jl
@@ -203,7 +203,7 @@ function calculate_overlap2(
     # Initialize secondary overlap container
     overlap = zeros(ComplexF32, num_planewaves*num_occ_states, num_target_orbitals)
     for i in 1:num_occ_states, j in 1:num_planewaves
-        direction = -(occ_states.G[j,i]+occ_states.kpt[j,i])
+        direction = -(occ_states.G[j]+KPoint(occ_states.skb[i]))
         # scaling factor is necessary, bc the STO is not necessarily at the origin
         scalingfactor = exp(2*im*pi*dot(direction, atom_pos_fract))
         d2 = direction'*reciprocal_lattice

--- a/src/raMO.jl
+++ b/src/raMO.jl
@@ -23,7 +23,7 @@ function make_overlap_mat(occ_states::OccupiedStates)
     # Checks to see if kpoint matches for the occ_states matrix
     allowed_overlap = zeros(Int,size(S))
     for u_kpt in u_kptlist
-        check_kpt = [kpt == u_kpt for kpt in kptlist[1,:]]
+        check_kpt = [kpt == u_kpt for kpt in kptlist[:]]
         allowed_overlap = allowed_overlap .+ (check_kpt.*check_kpt')
     end
     S = S.*allowed_overlap

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -73,7 +73,7 @@ function dftramo_run(filename::AbstractString)
                     # update remainders and number of electrons left
                     ramostatus.psi_previous = psi_previous2
                     ramostatus.num_electrons_left = Int(num_electrons_left2)
-                    ramostatus.num_raMO += i
+                    ramostatus.num_raMO += 1
                     output_files(r.name, ramostatus.num_electrons_left, ramostatus.num_raMO, ramostatus.supercell, isosurf, ramostatus.psi_previous, psi_up)
                 end
             end

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -87,7 +87,7 @@ function dftramo_run(filename::AbstractString)
                 # set raMO analysis to where the first low psphere occurred
                 # to prevent redundant raMO analysis
                 deleteat!(psphere_sites, collect(1:low_psphere[1]-1))
-                e = num_electrons_left - (low_psphere[1]-1)*2
+                e = ramostatus.num_electrons_left - (low_psphere[1]-1)*2
                 raMO = num_raMO + (low_psphere[1]-1)
                 (ramostatus.psi_previous, ramostatus.num_electrons_left, ramostatus.num_raMO) = import_checkpoint(string(r.name, "/", r.name, "_", raMO, "_", e, ".chkpt"))
                 aps = ""

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -88,7 +88,7 @@ function dftramo_run(filename::AbstractString)
                 # to prevent redundant raMO analysis
                 deleteat!(psphere_sites, collect(1:low_psphere[1]-1))
                 e = ramostatus.num_electrons_left - (low_psphere[1]-1)*2
-                raMO = num_raMO + (low_psphere[1]-1)
+                raMO = ramostatus.num_raMO + (low_psphere[1]-1)
                 (ramostatus.psi_previous, ramostatus.num_electrons_left, ramostatus.num_raMO) = import_checkpoint(string(r.name, "/", r.name, "_", raMO, "_", e, ".chkpt"))
                 aps = ""
                 # If the last raMOs were the only ones with low_psphere, no need to rerun

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -60,7 +60,7 @@ function dftramo_run(filename::AbstractString)
                 (sphere, total, psphere[i]) = Psphere(RealDataGrid(real(isosurf), basis(ramostatus.supercell)), sites, r.rsphere)
                 psphere_sites[i] = sites
                 open(string(r.name, "_psphere_", r.rsphere, ".txt"), "a") do io
-                    print_psphere_terminal(iter, ramostatus.num_raMO+i, psphere[i], sites, io)
+                    print_psphere_terminal(iter, ramostatus.num_raMO+1, psphere[i], sites, io)
                 end
                 # Check if we are in discard ramo mode
                 if ramoinput.mode == "discard"

--- a/test/dftramo_run.jl
+++ b/test/dftramo_run.jl
@@ -1,0 +1,6 @@
+@testset "dftramo_run" begin
+    cd("input/") do
+        @test dftramo_run("ScAl3_short.yaml") == nothing
+        rm("1_Sc-Sc", force=true, recursive=true)
+    end
+end

--- a/test/input/ScAl3.yaml
+++ b/test/input/ScAl3.yaml
@@ -9,26 +9,26 @@ runs:
     type: sp
     site_file: Sc-Sc_reordered.xyz
     sites: all
-    radius: 2.2
-    rsphere: 2.2
+    radius: 2.3
+    rsphere: 2.3
   - name: 2_Sc_dxy
     type: dxy
     site_file: 
     sites: Sc
     radius: 
-    rsphere: 2.2
+    rsphere: 3
   - name: 3_Sc_dxz
     type: dxz
     site_file: 
     sites: Sc
     radius: 
-    rsphere: 2.2
+    rsphere: 3
   - name: 4_Sc_dyz
     type: dyz
     site_file: 
     sites: Sc
     radius: 
-    rsphere: 2.2
+    rsphere: 3
   - name: 5_Al_oct
     type: sp
     site_file: Al-Al_reordered.xyz

--- a/test/input/ScAl3.yaml
+++ b/test/input/ScAl3.yaml
@@ -2,6 +2,7 @@ checkpoint:
 auto_psphere: true
 emin: -100 eV
 emax: 0.25 Ha
+mode: auto_psphere
 software: vasp
 runs:
   - name: 1_Sc-Sc

--- a/test/input/ScAl3_short.yaml
+++ b/test/input/ScAl3_short.yaml
@@ -1,0 +1,13 @@
+checkpoint:
+auto_psphere: true
+emin: -100 eV
+emax:
+software: vasp
+mode: discard
+runs:
+  - name: 1_Sc-Sc
+    type: sp
+    site_file: Sc-Sc_reordered.xyz
+    sites: all
+    radius: 2.2
+    rsphere: 2.2

--- a/test/inputs.jl
+++ b/test/inputs.jl
@@ -4,6 +4,7 @@
         @test length(ramoinput.runlist) == 5
         @test ramoinput.emin == -100*DFTraMO.Electrum.EV2HARTREE
         @test ramoinput.emax == 0.25
+        @test ramoinput.mode == "auto_psphere"
     end
 
     @test DFTraMO.parse_sites(["10", "10", "10:2:16"]) == [10, 12, 14, 16]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,5 @@ using DFTraMO
     # Add your tests here, ideally as file includes.
     include("inputs.jl")
     include("occupiedstates.jl")
+    include("dftramo_run.jl")
 end


### PR DESCRIPTION
Fixes the "mode" for DFT-raMO. Allows you to "discard" raMOs or use the "auto_psphere" mode. Some cleanup will be necessary later, but I'd like to push the changes now for functionality.