### PR TITLE
Fix/ramo checkpoint constructor

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -133,7 +133,7 @@ struct raMOCheckpoint{T<:Number} <: AbstractArray{T,3}
     electrons_left::Int
     num_ramos::Int
     function raMOCheckpoint{T}(
-        coeff::AbstractArray{3},
+        coeff::AbstractArray{<:Any,3},
         electrons_left::Integer,
         num_ramos::Integer
     ) where T


### PR DESCRIPTION
Minor fix - just realized the type signature for the first argument of the inner constructor of `raMOCheckpoint{T}` was an invalid type.