### PR TITLE
Refactor/wd

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -312,6 +312,7 @@ end
 
 raMODFTData(x::raMOInput) = x.dftdata
 OccupiedStates(x::raMOInput) = OccupiedStates(x.dftdata; emin = x.emin, emax = x.emax)
+mode(x::raMOInput) = x.mode
 
 Electrum.Crystal(x::raMOInput) = x.dftdata.xtal
 Electrum.basis(x::raMOInput) = basis(x.dftdata.xtal)
@@ -384,3 +385,6 @@ end
 
 Electrum.PeriodicAtomList(x::raMOStatus) = x.supercell.atomlist
 size_basis(x::raMOStatus) = size(x.psi_previous)[2]
+raMOInput(x::raMOStatus) = x.ramoinput
+raMODFTData(x::raMOStatus) = raMODFTData(raMOInput(x))
+OccupiedStates(x::raMOStatus) = x.occ_states

--- a/src/data.jl
+++ b/src/data.jl
@@ -264,32 +264,34 @@ struct raMOInput
     emax::Float64
     checkpoint::String  # TODO: should we use some sort of IO type? or checkpoint container?
     mode::String
+    wd::String
     function raMOInput(
         dftdata::raMODFTData,
         runlist,
         emin::Real,
         emax::Real,
         checkpoint::AbstractString,
-        mode::AbstractString
+        mode::AbstractString,
+        wd::AbstractString
     )
         @assert emin < emax "Minimum energy is not less than maximum energy"
-        return new(dftdata, collect(runlist), emin, emax, checkpoint, mode)
+        return new(dftdata, collect(runlist), emin, emax, checkpoint, mode, wd)
     end
 end
 
 """
-    raMOInput(
+    function raMOInput(
         dftdata::raMODFTData,
         runlist;
-        auto_psphere = false,
-        checkpoint = "",
-        emin = minimum(dftdata.wave.energies),
-        emax = fermi(dftdata)
+        emin::Real = minimum(dftdata.wave.energies),
+        emax::Real = fermi(dftdata),
+        checkpoint::AbstractString = "",
+        mode::AbstractString = ""
     )
 
 Constructs a `raMOInput` object with some assumptions implemented as keyword arguments.
 
-`auto_psphere` is set to false if not specified.
+`mode` is set to `discard` if not specified.
 
 If `checkpoint` is unset, the checkpoint path is the empty string, corresponding to no checkpoint
 file being used.
@@ -305,14 +307,16 @@ function raMOInput(
     emin::Real = minimum(dftdata.wave.energies),
     emax::Real = fermi(dftdata),
     checkpoint::AbstractString = "",
-    mode::AbstractString = ""
+    mode::AbstractString = "",
+    wd::AbstractString = pwd()
 )
-    return raMOInput(dftdata, runlist, emin, emax, checkpoint, mode)
+    return raMOInput(dftdata, runlist, emin, emax, checkpoint, mode, wd)
 end
 
 raMODFTData(x::raMOInput) = x.dftdata
 OccupiedStates(x::raMOInput) = OccupiedStates(x.dftdata; emin = x.emin, emax = x.emax)
 mode(x::raMOInput) = x.mode
+wd(x::raMOInput) = x.wd
 
 Electrum.Crystal(x::raMOInput) = x.dftdata.xtal
 Electrum.basis(x::raMOInput) = basis(x.dftdata.xtal)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -4,6 +4,7 @@
 Automatically runs DFTraMO from a configuration yaml file.
 """
 function dftramo_run(filename::AbstractString)
+    wd = pwd()
     # read inputs
     ramoinput = read_yaml(filename)
     # initialize data
@@ -19,7 +20,7 @@ function dftramo_run(filename::AbstractString)
         @info "Run: $(r.name)"
 
         # go into directory
-        split(pwd(),'/')[end] != r.name && !isdir(r.name) && mkdir(r.name)
+        split(wd,'/')[end] != r.name && !isdir(r.name) && mkdir(r.name)
         cd(r.name) do
             if !isempty(readdir())
                 @warn "Directory is not empty. Files will be deleted/overwritten."
@@ -27,7 +28,7 @@ function dftramo_run(filename::AbstractString)
             end
             psphere = Vector{Float64}(undef, length(r.sites))
             psphere_sites = Vector{SVector{3, Float64}}(undef, length(r.sites))
-            ramostatus = run_ramo(psphere, psphere_sites, r, ramoinput, ramostatus)
+            ramostatus = run_ramo(wd, psphere, psphere_sites, r, ramoinput, ramostatus)
             # If auto_psphere is enabled, rerun and use the new run
             low_psphere = psphere_eval(psphere, psphere_sites)
             if ramoinput.mode == "auto_psphere" && length(low_psphere)!=0
@@ -49,7 +50,7 @@ function dftramo_run(filename::AbstractString)
                     cd("aps") do 
                         psphere = Vector{Float64}(undef, length(psphere_sites))
                         psphere_sites = Vector{SVector{3, Float64}}(undef, length(psphere_sites))
-                        ramostatus = run_ramo(psphere, psphere_sites, r, ramoinput, ramostatus, low_psphere=low_psphere)
+                        ramostatus = run_ramo(wd, psphere, psphere_sites, r, ramoinput, ramostatus, low_psphere=low_psphere)
                     end
                     next = iterate(ramoinput, state)
                 end
@@ -65,7 +66,7 @@ end
 
 Runs the basic raMO code (necessary in a separate function for auto_psphere functionality)
 """
-function run_ramo(psphere, psphere_sites, r, ramoinput, ramostatus; low_psphere = Vector{Int}(undef, 0))
+function run_ramo(wd, psphere, psphere_sites, r, ramoinput, ramostatus; low_psphere = Vector{Int}(undef, 0))
     iter = ProgressBar(1:length(psphere), unit="raMOs")
     for i in iter
         # check to see if we have electrons left
@@ -90,7 +91,7 @@ function run_ramo(psphere, psphere_sites, r, ramoinput, ramostatus; low_psphere 
             target = make_target_AO(target_sites[i], get(AO_RUNS, r.type, 0), ramostatus.supercell)
             sites = basis(ramostatus.supercell)*Electrum.BOHR2ANG*PeriodicAtomList(ramostatus.supercell)[target_sites[i]].pos
         elseif r.type in CAGE_RUNS # for now we only have one type
-            sites = read_site_list(string("../", r.site_file))
+            sites = read_site_list(joinpath(wd, r.site_file))
             for n in reverse(low_psphere)
                 deleteat!(sites, n)
             end
@@ -98,7 +99,7 @@ function run_ramo(psphere, psphere_sites, r, ramoinput, ramostatus; low_psphere 
             target = make_target_cluster_sp(sites, r.radius, i, ramostatus.supercell)
             sites = sites[i]
         elseif r.type == "lcao"
-            lcao_yaml = YAML.load_file(string("../", r.site_file))
+            lcao_yaml = YAML.load_file(joinpath(wd, r.site_file))
             (target_orbital, site_list) = target_lcao(lcao_yaml)
             for n in reverse(low_psphere)
                 deleteat!(site_list, n)

--- a/src/yaml.jl
+++ b/src/yaml.jl
@@ -28,7 +28,7 @@ function dftramo_run(filename::AbstractString)
             end
             psphere = Vector{Float64}(undef, length(r.sites))
             psphere_sites = Vector{SVector{3, Float64}}(undef, length(r.sites))
-            ramostatus = run_ramo(wd, psphere, psphere_sites, r, ramostatus)
+            ramostatus = run_ramo(psphere, psphere_sites, r, ramostatus, wd=wd)
             # If auto_psphere is enabled, rerun and use the new run
             low_psphere = psphere_eval(psphere, psphere_sites)
             if mode(ramoinput) == "auto_psphere" && length(low_psphere)!=0
@@ -50,7 +50,7 @@ function dftramo_run(filename::AbstractString)
                     cd("aps") do 
                         psphere = Vector{Float64}(undef, length(psphere_sites))
                         psphere_sites = Vector{SVector{3, Float64}}(undef, length(psphere_sites))
-                        ramostatus = run_ramo(wd, psphere, psphere_sites, r, ramostatus, low_psphere=low_psphere)
+                        ramostatus = run_ramo(psphere, psphere_sites, r, ramostatus, low_psphere=low_psphere, wd=wd)
                     end
                     next = iterate(ramoinput, state)
                 end
@@ -62,11 +62,11 @@ function dftramo_run(filename::AbstractString)
 end
 
 """
-    run_ramo(wd, psphere, psphere_sites, r, ramostatus; low_psphere = Vector{Int}(undef, 0))
+    run_ramo(psphere, psphere_sites, r, ramostatus; low_psphere = Vector{Int}(undef, 0), wd::AbstractString=pwd())
 
 Runs the basic raMO code (necessary in a separate function for auto_psphere functionality)
 """
-function run_ramo(wd::AbstractString, psphere, psphere_sites, r, ramostatus; low_psphere = Vector{Int}(undef, 0))
+function run_ramo(psphere, psphere_sites, r, ramostatus; low_psphere = Vector{Int}(undef, 0), wd::AbstractString=pwd())
     iter = ProgressBar(1:length(psphere), unit="raMOs")
     for i in iter
         # check to see if we have electrons left


### PR DESCRIPTION
Now DFT-raMO will store and use the working directory instead of relative paths, which is helpful in the case of auto_psphere mode. I also added a couple of methods to access data in `raMOStatus`.